### PR TITLE
macOS System Integrity Protection (SIP) Fix

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -3,19 +3,19 @@
 
 # To be able to call ring from any folder 
 
-echo "`pwd`/ring \$1" > /usr/bin/ring
-chmod +x /usr/bin/ring
+echo "`pwd`/ring \$1" > /usr/local/bin/ring
+chmod +x /usr/local/bin/ring
 
 cd ..
 	
 if [ -f lib/libring.dylib ];
 then
-cp lib/libring.dylib /usr/lib
+cp lib/libring.dylib /usr/local/lib
 fi
 
 if [ -f lib/libring.so ];
 then
-cp lib/libring.so /usr/lib
+cp lib/libring.so /usr/local/lib
 fi
 	
 
@@ -23,36 +23,34 @@ fi
 	
 if [ -f lib/libringallegro.dylib ];
 then
-cp lib/libringallegro.dylib /usr/lib
+cp lib/libringallegro.dylib /usr/local/lib
 fi
 
 if [ -f lib/libringallegro.so ];
 then
-cp lib/libringallegro.so /usr/lib
+cp lib/libringallegro.so /usr/local/lib
 fi
 
 # Make the RingQt library ready for use directly
 	
 if [ -f lib/libringqt.dylib ];
 then
-cp lib/libringqt.dylib /usr/lib
+cp lib/libringqt.dylib /usr/local/lib
 fi
 
 if [ -f lib/libringqt.so ];
 then
-cp lib/libringqt.so /usr/lib
+cp lib/libringqt.so /usr/local/lib
 fi
 
 # Make the RingLibCurl library ready for use directly
 
 if [ -f lib/libring_libcurl.dylib ];
 then
-cp lib/libring_libcurl.dylib /usr/lib
+cp lib/libring_libcurl.dylib /usr/local/lib
 fi
 
 if [ -f lib/libring_libcurl.so ];
 then
-cp lib/libring_libcurl.so /usr/lib
+cp lib/libring_libcurl.so /usr/local/lib
 fi
-
-	


### PR DESCRIPTION
System Integrity Protection (SIP) is a new protection system built-in El-Capitan and later mac operation systems: https://support.apple.com/en-us/HT204899
Due to the SIP we cannot install the ring inside /usr/ without disabling this protection system, instead we will use /usr/local/.