### PR TITLE
replace tmpnam

### DIFF
--- a/src/ring_vmfile.c
+++ b/src/ring_vmfile.c
@@ -126,7 +126,8 @@ void ring_vm_file_tempfile ( void *pPointer )
 
 void ring_vm_file_tempname ( void *pPointer )
 {
-	RING_API_RETSTRING(tmpnam(NULL));
+	char _tmpfile[20] = "/tmp/ringtempXXXXXX";
+	RING_API_RETSTRING(mkdtemp(_tmpfile));
 }
 
 void ring_vm_file_fseek ( void *pPointer )


### PR DESCRIPTION
this patch replaces the tmpnam function by mkdtemp

according to tmpnam man page : 

> The tmpnam() function generates a different string each time it is called, up to TMP_MAX times. If it is called more than TMP_MAX times, the behavior is implementation defined.
> 
> Although tmpnam() generates names that are difficult to guess, **it is nevertheless possible that between the time that tmpnam() returns a pathname, and the time that the program opens it, another program might create that pathname using open(2), or create it as a symbolic link. This can lead to security holes.** To avoid such possibilities, use the open(2) O_EXCL flag to open the pathname. Or better yet, use mkstemp(3) or tmpfile(3).

However this patch needs to be tested in the others platforms, a little search led me to the following phrase: 

> Using mktemp is Unix-only for Windows you need tmpnam_s and _wtmpnam_s. Thus a platform-independent version is not that easy.

So don't know if that will be compiled in Windows or not.

my current environment : Ubuntu 16.04
