### PR TITLE
Implement autotools to ring

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,20 @@
+
+
+lib_LTLIBRARIES = libring.la
+libring_la_SOURCES = include/ring.h src/ring_state.c src/ring_ext.c \
+    src/ring_hashlib.c src/ring_hashtable.c src/ring_vmgc.c \
+    src/ring_vmos.c src/ring_string.c src/ring_list.c src/ring_item.c \
+    src/ring_items.c src/ring_scanner.c src/ring_parser.c \
+    src/ring_stmt.c src/ring_expr.c src/ring_codegen.c \
+    src/ring_vm.c src/ring_vmexpr.c src/ring_vmvars.c src/ring_vmlists.c \
+    src/ring_vmfuncs.c src/ring_api.c src/ring_vmoop.c src/ring_vmcui.c \
+    src/ring_vmtrycatch.c src/ring_vmstrindex.c src/ring_vmjump.c \
+    src/ring_vmduprange.c src/ring_vmlistfuncs.c \
+    src/ring_vmrefmeta.c src/ring_vmperformance.c src/ring_vmexit.c \
+    src/ring_vmstackvars.c src/ring_vmstate.c src/ring_vmmath.c \
+    src/ring_vmfile.c src/ring_vmdll.c src/ring_objfile.c
+libring_la_CFLAGS = -I$(top_srcdir)/include -lm -ldl
+
+bin_PROGRAMS = ring
+ring_SOURCES = src/ring.c
+ring_CFLAGS = -L$(top_srcdir)/lib -lring  -I$(top_srcdir)/include

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,24 @@
+dnl Ring 1.5.4
+
+dnl initializing the autoconf tool
+AC_INIT([ring], [1.5.4])
+
+dnl make sure that this main file is exists before compiling
+AC_CONFIG_SRCDIR([src/ring.c])
+
+AM_PROG_AR
+
+dnl init LT to be able to compile specific files as shared libraries
+LT_INIT
+
+dnl path the main options to Makefile.am
+AM_INIT_AUTOMAKE([-Wall foreign subdir-objects])
+
+dnl specify and create the Makefile
+AC_CONFIG_FILES([Makefile])
+
+dnl find the probe compiler
+AC_PROG_CC
+
+dnl output the final files
+AC_OUTPUT


### PR DESCRIPTION
Implement the uinux-like autotools into ring, this is not a final commit, it's a kernel for upcoming commits.

TODO :- 
* set the prober path to move ring binary to.
* in ubuntu there are another program called `ring` comes with the `alliance` package so we need to make another check for that.
* add options to support --enable-**extension** in the ./configure phase instead of manually compile every extension.
* add a small shell file to handle the basic autotool steps, mainly to make sure of that autotools is exists on the system and execute the command `autoreconf -i`
* the previous shell script or the Makefile itself may structure a two important directories :- 
** /etc/ring/XXX to hold any upcoming probably configurations files.
** /usr/lib/ring/XXX to hold any *.so file in a one directory instead of being in the /usr/lib
* define some env variables.
* Upcoming TODOS.

until now, this files working grace in my side and compiled successfully, but still need some enhancements.

![screenshot from 2017-10-29 23-17-45](https://user-images.githubusercontent.com/4136671/32148423-692b942c-bcff-11e7-94f0-c13656118b03.png)
