### PR TITLE
Autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,9 +14,9 @@ libring_la_SOURCES = include/ring.h src/ring_state.c src/ring_ext.c \
     src/ring_vmstackvars.c src/ring_vmstate.c src/ring_vmmath.c \
     src/ring_vmfile.c src/ring_vmdll.c src/ring_objfile.c
 libring_la_CFLAGS = -I$(top_srcdir)/include -lm -ldl
-libring_la_LDFLAGS = -R /usr/local/lib/ring/
+libring_la_LDFLAGS = -R /usr/local/lib/ring/ -R /usr/local/lib/ring/extensions/
 
 bin_PROGRAMS = ring
 ring_SOURCES = src/ring.c
 ring_CFLAGS = -L$(top_srcdir)/lib -lring  -I$(top_srcdir)/include
-ring_LDFLAGS = -R /usr/local/lib/ring/
+ring_LDFLAGS = -R /usr/local/lib/ring/ -R /usr/local/lib/ring/extensions/

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,9 @@ libring_la_SOURCES = include/ring.h src/ring_state.c src/ring_ext.c \
     src/ring_vmstackvars.c src/ring_vmstate.c src/ring_vmmath.c \
     src/ring_vmfile.c src/ring_vmdll.c src/ring_objfile.c
 libring_la_CFLAGS = -I$(top_srcdir)/include -lm -ldl
+libring_la_LDFLAGS = -R /usr/local/lib/ring/
 
 bin_PROGRAMS = ring
 ring_SOURCES = src/ring.c
 ring_CFLAGS = -L$(top_srcdir)/lib -lring  -I$(top_srcdir)/include
+ring_LDFLAGS = -R /usr/local/lib/ring/

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,8 @@ libring_la_SOURCES = include/ring.h src/ring_state.c src/ring_ext.c \
     src/ring_vmstackvars.c src/ring_vmstate.c src/ring_vmmath.c \
     src/ring_vmfile.c src/ring_vmdll.c src/ring_objfile.c
 libring_la_CFLAGS = -I$(top_srcdir)/include -lm -ldl
-libring_la_LDFLAGS = -R /usr/local/lib/ring/ -R /usr/local/lib/ring/extensions/
+libring_la_LDFLAGS = -R /usr/local/lib/ring/ -R /usr/local/lib/ring/extensions/ \
+	-avoid-version -shared -export-dynamic
 
 bin_PROGRAMS = ring
 ring_SOURCES = src/ring.c

--- a/build/RING.m4
+++ b/build/RING.m4
@@ -1,0 +1,9 @@
+AC_DEFUN([RING_INCLUDE_EXTENSION], [
+    ext_dir="ring$1"
+    cp build/Makefile.tmp extensions/$ext_dir/Makefile.am
+
+    flags="-I."
+
+    sed -i -- "s/{ext_name}/$1/g" extensions/$ext_dir/Makefile.am
+    sed -i -- "s/{ext_cflags}/$flags/g" extensions/$ext_dir/Makefile.am
+])

--- a/build/RING.m4
+++ b/build/RING.m4
@@ -1,9 +1,41 @@
+
+AC_DEFUN([_LIST_FULL_EXT_SOURCES], [
+    dir="$1"
+    ring_extension_source=`find $dir -name '*.c'`
+    unset -v dir
+])
+
+dnl
+dnl RING_INCLUDE_EXTENSION([ext_name], [ext_sources], [cflags], [ld_flags])
 AC_DEFUN([RING_INCLUDE_EXTENSION], [
     ext_dir="ring$1"
-    cp build/Makefile.tmp extensions/$ext_dir/Makefile.am
+    ext_name="$1"
+    ext_sources="$2"
+    ext_cflags="$3"
+    ext_ldflags="$4"
+    is_shared="$5"
 
-    flags="-I."
+    echo $ext_dir
+    echo $ext_name
+    echo $ext_sources
+    echo $ext_cflags
+    echo $ext_ldflags
 
-    sed -i -- "s/{ext_name}/$1/g" extensions/$ext_dir/Makefile.am
-    sed -i -- "s/{ext_cflags}/$flags/g" extensions/$ext_dir/Makefile.am
+    ext_path="$RINGEXT_DIR/$ext_dir/"
+
+    _LIST_FULL_EXT_SOURCES($ext_path)
+
+    echo $ring_extension_source
+
+    sub_dirs="$sub_dirs $ext_path"
+
+    echo $sub_dirs;
+
+    AC_MSG_ERROR
+    dnl cp build/Makefile.tmp extensions/$ext_dir/Makefile.am
+
+    dnl flags="-I."
+
+    dnl sed -i -- "s/{ext_name}/$1/g" extensions/$ext_dir/Makefile.am
+    dnl sed -i -- "s/{ext_cflags}/$flags/g" extensions/$ext_dir/Makefile.am
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,17 @@ dnl the user can not change the library directory, this
 dnl should be fixed.
 libdir=/usr/local/lib/ring
 
+
+AC_ARG_ENABLE([mysql],
+    AS_HELP_STRING([--enable-mysql], [Enable Mysql extension])
+)
+
+AS_IF([test "ring_$enable_mysql" == "ring_yes"], [
+    dnl compile mysql extension!
+    RING_INCLUDE_EXTENSION([mysql])
+])
+
+
 dnl path the main options to Makefile.am
 AM_INIT_AUTOMAKE([-Wall foreign subdir-objects])
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,20 @@ dnl Ring 1.5.4
 dnl initializing the autoconf tool
 AC_INIT([ring], [1.5.4])
 
+RING_VERSION="1.5.4"
+RING_SRC_DIR="src/"
+RING_INCLUDE_DIR="include/"
+RING_EXT_DIR="extension/"
+
+RING_SUB_DIRS="$RING_SRC_DIR"
+
+AC_SUBST(RING_VERSION)
+AC_SUBST(RING_SRC_DIR)
+AC_SUBST(RING_INCLUDE_DIR)
+AC_SUBST(RING_EXT_DIR)
+
+m4_include(build/RING.m4)
+
 dnl Set the main m4 macros directory
 AC_CONFIG_MACRO_DIRS([build/m4])
 


### PR DESCRIPTION
the RING.m4 is still under constructions, and can not be used right now.

this commit is part of autotools patch, this aims to give the ability to use autotools and make the benefits of it.

the upcoming is to give the user the power of using ./configure script to choose his preferable flavours of ring extensions to be compiled with ring.