### PR TITLE
Murmurhash extension

### DIFF
--- a/extensions/ringmurmurhash/README.md
+++ b/extensions/ringmurmurhash/README.md
@@ -1,0 +1,47 @@
+### Murmurhash Extensions :-
+
+#### MurmurHash library :-
+> MurmurHash is a non-cryptographic hash function suitable for general hash-based lookup.  
+> It was created by Austin Appleby in 2008 and is currently hosted on Github along with its test suite named 'SMHasher'.  
+> It also exists in a number of variants,[5] all of which have been released into the public domain.  
+> The name comes from two basic operations, multiply (MU) and rotate (R), used in its inner loop.
+
+Murmurhash extension is an extension written to implement a full implementation for the MurmurHash library.
+
+
+##### Available functions :-
+
+```c
+/* MurmurHash1 functions */
+uint32_t murmurhash1(string key, int seed, [bool return_type]);
+uint32_t murmurhash1_aligned(string key, int seed, [bool return_type]);
+
+/* MurmurHash2 functions */
+uint32_t murmurhash2(string key, int seed, [bool return_type]);
+uint32_t murmurhash2a(string key, int seed, [bool return_type]);
+uint64_t murmurhash64a(string key, int seed, [bool return_type]);
+uint64_t murmurhash64b(string key, int seed, [bool return_type]);
+uint32_t murmurhash_neutral2(string key, int seed, [bool return_type]);
+uint32_t murmurhash_aligned2(string key, int seed, [bool return_type]);
+
+/* MurmurHash3 functions */
+uint32_t murmurhash3_x86_32(string key, int seed, [bool return_type]);
+list murmurhash3_x86_128(string key, int seed, [bool return_type]);
+list murmurhash3_x64_128(string key, int seed, [bool return_type]);
+```
+
+The third *optional* parameter is to set the type of the returned value, this parameter accepts a bool value [ true, false ],
+true will return a **Hex** value, while false will return a integer value.
+
+
+##### Example :-
+```
+key = "Ring Language"
+
+see murmurhash3_x86_32(key, 0, 0) + nl // Output: 1894444853
+see murmurhash3_x86_32(key, 0, 1) + nl // Output: 70eaef35
+```
+
+You can check the other examples within the tests folder.
+
+Don't forget to run tests in the tests directory and come back with an unexpected behavior or if in case any problems happened.

--- a/extensions/ringmurmurhash/buildclang.sh
+++ b/extensions/ringmurmurhash/buildclang.sh
@@ -1,0 +1,13 @@
+# TODO : convert into autotools
+
+mkdir lib/
+
+clang -c -fpic ring_murmurhash.c libmurmurhash/MurmurHash1.c \
+    libmurmurhash/MurmurHash2.c libmurmurhash/MurmurHash3.c \
+    -g -Wall -O3 -I $PWD/../../include -I libmurmurhash/
+
+clang -dynamiclib -o lib/libring_murmurhash.dylib *.o
+
+rm *.o
+
+cp lib/libring_murmurhash.dylib /usr/local/lib/ring/libring_murmurhash.dylib

--- a/extensions/ringmurmurhash/buildgcc.sh
+++ b/extensions/ringmurmurhash/buildgcc.sh
@@ -1,0 +1,11 @@
+# TODO : convert into autotools
+
+mkdir lib/
+
+gcc -c -fpic ring_murmurhash.c libmurmurhash/MurmurHash1.c \
+    libmurmurhash/MurmurHash2.c libmurmurhash/MurmurHash3.c \
+    -g -Wall -I $PWD/../../include -I. -O3
+
+gcc --shared -o lib/libringmurmurhash.so *.o
+
+rm *.o

--- a/extensions/ringmurmurhash/buildgcc.sh
+++ b/extensions/ringmurmurhash/buildgcc.sh
@@ -4,8 +4,10 @@ mkdir lib/
 
 gcc -c -fpic ring_murmurhash.c libmurmurhash/MurmurHash1.c \
     libmurmurhash/MurmurHash2.c libmurmurhash/MurmurHash3.c \
-    -g -Wall -I $PWD/../../include -I. -O3
+    -g -Wall -O3 -I $PWD/../../include -I libmurmurhash/
 
 gcc --shared -o lib/libringmurmurhash.so *.o
 
 rm *.o
+
+cp lib/libringmurmurhash.so /usr/local/lib/ring/libring_murmurhash.so

--- a/extensions/ringmurmurhash/buildvc.bat
+++ b/extensions/ringmurmurhash/buildvc.bat
@@ -1,0 +1,11 @@
+MD lib
+
+cls
+call ../../src/locatevc.bat
+cl /c /DEBUG ring_murmurhash.c libmurmurhash/MurmurHash1.c \
+    libmurmurhash/MurmurHash2.c libmurmurhash/MurmurHash3.c \
+     -I"../../include" -I"libmurmurhash/"
+
+
+link /DEBUG *.obj ..\..\lib\ring.lib /DLL /OUT:lib\ring_murmurhash.dll /SUBSYSTEM:CONSOLE,"5.01" 
+del *.obj

--- a/extensions/ringmurmurhash/libmurmurhash/MurmurHash1.c
+++ b/extensions/ringmurmurhash/libmurmurhash/MurmurHash1.c
@@ -1,0 +1,174 @@
+//-----------------------------------------------------------------------------
+// MurmurHash was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+// Note - This code makes a few assumptions about how your machine behaves -
+
+// 1. We can read a 4-byte value from any address without crashing
+// 2. sizeof(int) == 4
+
+// And it has a few limitations -
+
+// 1. It will not work incrementally.
+// 2. It will not produce the same results on little-endian and big-endian
+//    machines.
+
+#include "MurmurHash1.h"
+
+//-----------------------------------------------------------------------------
+
+uint32_t MurmurHash1 ( const void * key, int len, uint32_t seed )
+{
+  const unsigned int m = 0xc6a4a793;
+
+  const int r = 16;
+
+  unsigned int h = seed ^ (len * m);
+
+  //----------
+  
+  const unsigned char * data = (const unsigned char *)key;
+
+  while(len >= 4)
+  {
+    unsigned int k = *(unsigned int *)data;
+
+    h += k;
+    h *= m;
+    h ^= h >> 16;
+
+    data += 4;
+    len -= 4;
+  }
+  
+  //----------
+  
+  switch(len)
+  {
+  case 3:
+    h += data[2] << 16;
+  case 2:
+    h += data[1] << 8;
+  case 1:
+    h += data[0];
+    h *= m;
+    h ^= h >> r;
+  };
+ 
+  //----------
+
+  h *= m;
+  h ^= h >> 10;
+  h *= m;
+  h ^= h >> 17;
+
+  return h;
+} 
+
+//-----------------------------------------------------------------------------
+// MurmurHash1Aligned, by Austin Appleby
+
+// Same algorithm as MurmurHash1, but only does aligned reads - should be safer
+// on certain platforms. 
+
+// Performance should be equal to or better than the simple version.
+
+unsigned int MurmurHash1Aligned ( const void * key, int len, unsigned int seed )
+{
+  const unsigned int m = 0xc6a4a793;
+  const int r = 16;
+
+  const unsigned char * data = (const unsigned char *)key;
+
+  unsigned int h = seed ^ (len * m);
+
+  int align = (uint64_t)data & 3;
+
+  if(align && (len >= 4))
+  {
+    // Pre-load the temp registers
+
+    unsigned int t = 0, d = 0;
+
+    switch(align)
+    {
+      case 1: t |= data[2] << 16;
+      case 2: t |= data[1] << 8;
+      case 3: t |= data[0];
+    }
+
+    t <<= (8 * align);
+
+    data += 4-align;
+    len -= 4-align;
+
+    int sl = 8 * (4-align);
+    int sr = 8 * align;
+
+    // Mix
+
+    while(len >= 4)
+    {
+      d = *(unsigned int *)data;
+      t = (t >> sr) | (d << sl);
+      h += t;
+      h *= m;
+      h ^= h >> r;
+      t = d;
+
+      data += 4;
+      len -= 4;
+    }
+
+    // Handle leftover data in temp registers
+
+    int pack = len < align ? len : align;
+
+    d = 0;
+
+    switch(pack)
+    {
+    case 3: d |= data[2] << 16;
+    case 2: d |= data[1] << 8;
+    case 1: d |= data[0];
+    case 0: h += (t >> sr) | (d << sl);
+        h *= m;
+        h ^= h >> r;
+    }
+
+    data += pack;
+    len -= pack;
+  }
+  else
+  {
+    while(len >= 4)
+    {
+      h += *(unsigned int *)data;
+      h *= m;
+      h ^= h >> r;
+
+      data += 4;
+      len -= 4;
+    }
+  }
+
+  //----------
+  // Handle tail bytes
+
+  switch(len)
+  {
+  case 3: h += data[2] << 16;
+  case 2: h += data[1] << 8;
+  case 1: h += data[0];
+      h *= m;
+      h ^= h >> r;
+  };
+
+  h *= m;
+  h ^= h >> 10;
+  h *= m;
+  h ^= h >> 17;
+
+  return h;
+}
+

--- a/extensions/ringmurmurhash/libmurmurhash/MurmurHash1.h
+++ b/extensions/ringmurmurhash/libmurmurhash/MurmurHash1.h
@@ -1,0 +1,34 @@
+//-----------------------------------------------------------------------------
+// MurmurHash1 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+#ifndef _MURMURHASH1_H_
+#define _MURMURHASH1_H_
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER) && (_MSC_VER < 1600)
+
+typedef unsigned char uint8_t;
+typedef unsigned int uint32_t;
+typedef unsigned __int64 uint64_t;
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
+#include <stdint.h>
+
+#endif // !defined(_MSC_VER)
+
+//-----------------------------------------------------------------------------
+
+uint32_t MurmurHash1        ( const void * key, int len, uint32_t seed );
+uint32_t MurmurHash1Aligned ( const void * key, int len, uint32_t seed );
+
+//-----------------------------------------------------------------------------
+
+#endif // _MURMURHASH1_H_

--- a/extensions/ringmurmurhash/libmurmurhash/MurmurHash2.c
+++ b/extensions/ringmurmurhash/libmurmurhash/MurmurHash2.c
@@ -1,0 +1,522 @@
+//-----------------------------------------------------------------------------
+// MurmurHash2 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+// Note - This code makes a few assumptions about how your machine behaves -
+
+// 1. We can read a 4-byte value from any address without crashing
+// 2. sizeof(int) == 4
+
+// And it has a few limitations -
+
+// 1. It will not work incrementally.
+// 2. It will not produce the same results on little-endian and big-endian
+//    machines.
+
+#include "MurmurHash2.h"
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER)
+
+#define BIG_CONSTANT(x) (x)
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
+#define BIG_CONSTANT(x) (x##LLU)
+
+#endif // !defined(_MSC_VER)
+
+//-----------------------------------------------------------------------------
+
+uint32_t MurmurHash2 ( const void * key, int len, uint32_t seed )
+{
+  // 'm' and 'r' are mixing constants generated offline.
+  // They're not really 'magic', they just happen to work well.
+
+  const uint32_t m = 0x5bd1e995;
+  const int r = 24;
+
+  // Initialize the hash to a 'random' value
+
+  uint32_t h = seed ^ len;
+
+  // Mix 4 bytes at a time into the hash
+
+  const unsigned char * data = (const unsigned char *)key;
+
+  while(len >= 4)
+  {
+    uint32_t k = *(uint32_t*)data;
+
+    k *= m;
+    k ^= k >> r;
+    k *= m;
+
+    h *= m;
+    h ^= k;
+
+    data += 4;
+    len -= 4;
+  }
+
+  // Handle the last few bytes of the input array
+
+  switch(len)
+  {
+  case 3: h ^= data[2] << 16;
+  case 2: h ^= data[1] << 8;
+  case 1: h ^= data[0];
+      h *= m;
+  };
+
+  // Do a few final mixes of the hash to ensure the last few
+  // bytes are well-incorporated.
+
+  h ^= h >> 13;
+  h *= m;
+  h ^= h >> 15;
+
+  return h;
+}
+
+//-----------------------------------------------------------------------------
+// MurmurHash2, 64-bit versions, by Austin Appleby
+
+// The same caveats as 32-bit MurmurHash2 apply here - beware of alignment
+// and endian-ness issues if used across multiple platforms.
+
+// 64-bit hash for 64-bit platforms
+
+uint64_t MurmurHash64A ( const void * key, int len, uint64_t seed )
+{
+  const uint64_t m = BIG_CONSTANT(0xc6a4a7935bd1e995);
+  const int r = 47;
+
+  uint64_t h = seed ^ (len * m);
+
+  const uint64_t * data = (const uint64_t *)key;
+  const uint64_t * end = data + (len/8);
+
+  while(data != end)
+  {
+    uint64_t k = *data++;
+
+    k *= m;
+    k ^= k >> r;
+    k *= m;
+
+    h ^= k;
+    h *= m;
+  }
+
+  const unsigned char * data2 = (const unsigned char*)data;
+
+  switch(len & 7)
+  {
+  case 7: h ^= ((uint64_t)(data2[6])) << 48;
+  case 6: h ^= ((uint64_t)(data2[5])) << 40;
+  case 5: h ^= ((uint64_t)(data2[4])) << 32;
+  case 4: h ^= ((uint64_t)(data2[3])) << 24;
+  case 3: h ^= ((uint64_t)(data2[2])) << 16;
+  case 2: h ^= ((uint64_t)(data2[1])) << 8;
+  case 1: h ^= ((uint64_t)(data2[0]));
+          h *= m;
+  };
+
+  h ^= h >> r;
+  h *= m;
+  h ^= h >> r;
+
+  return h;
+}
+
+
+// 64-bit hash for 32-bit platforms
+
+uint64_t MurmurHash64B ( const void * key, int len, uint64_t seed )
+{
+  const uint32_t m = 0x5bd1e995;
+  const int r = 24;
+
+  uint32_t h1 = ((uint32_t)(seed)) ^ len;
+  uint32_t h2 = ((uint32_t)(seed >> 32));
+
+  const uint32_t * data = (const uint32_t *)key;
+
+  while(len >= 8)
+  {
+    uint32_t k1 = *data++;
+    k1 *= m; k1 ^= k1 >> r; k1 *= m;
+    h1 *= m; h1 ^= k1;
+    len -= 4;
+
+    uint32_t k2 = *data++;
+    k2 *= m; k2 ^= k2 >> r; k2 *= m;
+    h2 *= m; h2 ^= k2;
+    len -= 4;
+  }
+
+  if(len >= 4)
+  {
+    uint32_t k1 = *data++;
+    k1 *= m; k1 ^= k1 >> r; k1 *= m;
+    h1 *= m; h1 ^= k1;
+    len -= 4;
+  }
+
+  switch(len)
+  {
+  case 3: h2 ^= ((unsigned char*)data)[2] << 16;
+  case 2: h2 ^= ((unsigned char*)data)[1] << 8;
+  case 1: h2 ^= ((unsigned char*)data)[0];
+      h2 *= m;
+  };
+
+  h1 ^= h2 >> 18; h1 *= m;
+  h2 ^= h1 >> 22; h2 *= m;
+  h1 ^= h2 >> 17; h1 *= m;
+  h2 ^= h1 >> 19; h2 *= m;
+
+  uint64_t h = h1;
+
+  h = (h << 32) | h2;
+
+  return h;
+}
+
+//-----------------------------------------------------------------------------
+// MurmurHash2A, by Austin Appleby
+
+// This is a variant of MurmurHash2 modified to use the Merkle-Damgard
+// construction. Bulk speed should be identical to Murmur2, small-key speed
+// will be 10%-20% slower due to the added overhead at the end of the hash.
+
+// This variant fixes a minor issue where null keys were more likely to
+// collide with each other than expected, and also makes the function
+// more amenable to incremental implementations.
+
+#define mmix(h,k) { k *= m; k ^= k >> r; k *= m; h *= m; h ^= k; }
+
+uint32_t MurmurHash2A ( const void * key, int len, uint32_t seed )
+{
+  const uint32_t m = 0x5bd1e995;
+  const int r = 24;
+  uint32_t l = len;
+
+  const unsigned char * data = (const unsigned char *)key;
+
+  uint32_t h = seed;
+
+  while(len >= 4)
+  {
+    uint32_t k = *(uint32_t*)data;
+
+    mmix(h,k);
+
+    data += 4;
+    len -= 4;
+  }
+
+  uint32_t t = 0;
+
+  switch(len)
+  {
+  case 3: t ^= data[2] << 16;
+  case 2: t ^= data[1] << 8;
+  case 1: t ^= data[0];
+  };
+
+  mmix(h,t);
+  mmix(h,l);
+
+  h ^= h >> 13;
+  h *= m;
+  h ^= h >> 15;
+
+  return h;
+}
+
+//-----------------------------------------------------------------------------
+// CMurmurHash2A, by Austin Appleby
+
+// This is a sample implementation of MurmurHash2A designed to work
+// incrementally.
+
+// Usage -
+
+// CMurmurHash2A hasher
+// hasher.Begin(seed);
+// hasher.Add(data1,size1);
+// hasher.Add(data2,size2);
+// ...
+// hasher.Add(dataN,sizeN);
+// uint32_t hash = hasher.End()
+/*
+class CMurmurHash2A
+{
+public:
+
+  void Begin ( uint32_t seed = 0 )
+  {
+    m_hash  = seed;
+    m_tail  = 0;
+    m_count = 0;
+    m_size  = 0;
+  }
+
+  void Add ( const unsigned char * data, int len )
+  {
+    m_size += len;
+
+    MixTail(data,len);
+
+    while(len >= 4)
+    {
+      uint32_t k = *(uint32_t*)data;
+
+      mmix(m_hash,k);
+
+      data += 4;
+      len -= 4;
+    }
+
+    MixTail(data,len);
+  }
+
+  uint32_t End ( void )
+  {
+    mmix(m_hash,m_tail);
+    mmix(m_hash,m_size);
+
+    m_hash ^= m_hash >> 13;
+    m_hash *= m;
+    m_hash ^= m_hash >> 15;
+
+    return m_hash;
+  }
+
+private:
+
+  static const uint32_t m = 0x5bd1e995;
+  static const int r = 24;
+
+  void MixTail ( const unsigned char * & data, int & len )
+  {
+    while( len && ((len<4) || m_count) )
+    {
+      m_tail |= (*data++) << (m_count * 8);
+
+      m_count++;
+      len--;
+
+      if(m_count == 4)
+      {
+        mmix(m_hash,m_tail);
+        m_tail = 0;
+        m_count = 0;
+      }
+    }
+  }
+
+  uint32_t m_hash;
+  uint32_t m_tail;
+  uint32_t m_count;
+  uint32_t m_size;
+};
+*/
+//-----------------------------------------------------------------------------
+// MurmurHashNeutral2, by Austin Appleby
+
+// Same as MurmurHash2, but endian- and alignment-neutral.
+// Half the speed though, alas.
+
+uint32_t MurmurHashNeutral2 ( const void * key, int len, uint32_t seed )
+{
+  const uint32_t m = 0x5bd1e995;
+  const int r = 24;
+
+  uint32_t h = seed ^ len;
+
+  const unsigned char * data = (const unsigned char *)key;
+
+  while(len >= 4)
+  {
+    uint32_t k;
+
+    k  = data[0];
+    k |= data[1] << 8;
+    k |= data[2] << 16;
+    k |= data[3] << 24;
+
+    k *= m;
+    k ^= k >> r;
+    k *= m;
+
+    h *= m;
+    h ^= k;
+
+    data += 4;
+    len -= 4;
+  }
+
+  switch(len)
+  {
+  case 3: h ^= data[2] << 16;
+  case 2: h ^= data[1] << 8;
+  case 1: h ^= data[0];
+          h *= m;
+  };
+
+  h ^= h >> 13;
+  h *= m;
+  h ^= h >> 15;
+
+  return h;
+}
+
+//-----------------------------------------------------------------------------
+// MurmurHashAligned2, by Austin Appleby
+
+// Same algorithm as MurmurHash2, but only does aligned reads - should be safer
+// on certain platforms.
+
+// Performance will be lower than MurmurHash2
+
+#define MIX(h,k,m) { k *= m; k ^= k >> r; k *= m; h *= m; h ^= k; }
+
+
+uint32_t MurmurHashAligned2 ( const void * key, int len, uint32_t seed )
+{
+  const uint32_t m = 0x5bd1e995;
+  const int r = 24;
+
+  const unsigned char * data = (const unsigned char *)key;
+
+  uint32_t h = seed ^ len;
+
+  int align = (uint64_t)data & 3;
+
+  if(align && (len >= 4))
+  {
+    // Pre-load the temp registers
+
+    uint32_t t = 0, d = 0;
+
+    switch(align)
+    {
+      case 1: t |= data[2] << 16;
+      case 2: t |= data[1] << 8;
+      case 3: t |= data[0];
+    }
+
+    t <<= (8 * align);
+
+    data += 4-align;
+    len -= 4-align;
+
+    int sl = 8 * (4-align);
+    int sr = 8 * align;
+
+    // Mix
+
+    while(len >= 4)
+    {
+      d = *(uint32_t *)data;
+      t = (t >> sr) | (d << sl);
+
+      uint32_t k = t;
+
+      MIX(h,k,m);
+
+      t = d;
+
+      data += 4;
+      len -= 4;
+    }
+
+    // Handle leftover data in temp registers
+
+    d = 0;
+
+    if(len >= align)
+    {
+      switch(align)
+      {
+      case 3: d |= data[2] << 16;
+      case 2: d |= data[1] << 8;
+      case 1: d |= data[0];
+      }
+
+      uint32_t k = (t >> sr) | (d << sl);
+      MIX(h,k,m);
+
+      data += align;
+      len -= align;
+
+      //----------
+      // Handle tail bytes
+
+      switch(len)
+      {
+      case 3: h ^= data[2] << 16;
+      case 2: h ^= data[1] << 8;
+      case 1: h ^= data[0];
+          h *= m;
+      };
+    }
+    else
+    {
+      switch(len)
+      {
+      case 3: d |= data[2] << 16;
+      case 2: d |= data[1] << 8;
+      case 1: d |= data[0];
+      case 0: h ^= (t >> sr) | (d << sl);
+          h *= m;
+      }
+    }
+
+    h ^= h >> 13;
+    h *= m;
+    h ^= h >> 15;
+
+    return h;
+  }
+  else
+  {
+    while(len >= 4)
+    {
+      uint32_t k = *(uint32_t *)data;
+
+      MIX(h,k,m);
+
+      data += 4;
+      len -= 4;
+    }
+
+    //----------
+    // Handle tail bytes
+
+    switch(len)
+    {
+    case 3: h ^= data[2] << 16;
+    case 2: h ^= data[1] << 8;
+    case 1: h ^= data[0];
+        h *= m;
+    };
+
+    h ^= h >> 13;
+    h *= m;
+    h ^= h >> 15;
+
+    return h;
+  }
+}
+
+//-----------------------------------------------------------------------------

--- a/extensions/ringmurmurhash/libmurmurhash/MurmurHash2.h
+++ b/extensions/ringmurmurhash/libmurmurhash/MurmurHash2.h
@@ -1,0 +1,39 @@
+//-----------------------------------------------------------------------------
+// MurmurHash2 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+#ifndef _MURMURHASH2_H_
+#define _MURMURHASH2_H_
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER) && (_MSC_VER < 1600)
+
+typedef unsigned char uint8_t;
+typedef unsigned int uint32_t;
+typedef unsigned __int64 uint64_t;
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
+#include <stdint.h>
+
+#endif // !defined(_MSC_VER)
+
+//-----------------------------------------------------------------------------
+
+uint32_t MurmurHash2        ( const void * key, int len, uint32_t seed );
+uint64_t MurmurHash64A      ( const void * key, int len, uint64_t seed );
+uint64_t MurmurHash64B      ( const void * key, int len, uint64_t seed );
+uint32_t MurmurHash2A       ( const void * key, int len, uint32_t seed );
+uint32_t MurmurHashNeutral2 ( const void * key, int len, uint32_t seed );
+uint32_t MurmurHashAligned2 ( const void * key, int len, uint32_t seed );
+
+//-----------------------------------------------------------------------------
+
+#endif // _MURMURHASH2_H_
+

--- a/extensions/ringmurmurhash/libmurmurhash/MurmurHash3.c
+++ b/extensions/ringmurmurhash/libmurmurhash/MurmurHash3.c
@@ -1,0 +1,335 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+// Note - The x86 and x64 versions do _not_ produce the same results, as the
+// algorithms are optimized for their respective platforms. You can still
+// compile and run any of them on any platform, but your performance with the
+// non-native version will be less than optimal.
+
+#include "MurmurHash3.h"
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER)
+
+#define FORCE_INLINE	__forceinline
+
+#include <stdlib.h>
+
+#define ROTL32(x,y)	_rotl(x,y)
+#define ROTL64(x,y)	_rotl64(x,y)
+
+#define BIG_CONSTANT(x) (x)
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
+#define	FORCE_INLINE inline __attribute__((always_inline))
+
+inline uint32_t rotl32 ( uint32_t x, int8_t r )
+{
+  return (x << r) | (x >> (32 - r));
+}
+
+inline uint64_t rotl64 ( uint64_t x, int8_t r )
+{
+  return (x << r) | (x >> (64 - r));
+}
+
+#define	ROTL32(x,y)	rotl32(x,y)
+#define ROTL64(x,y)	rotl64(x,y)
+
+#define BIG_CONSTANT(x) (x##LLU)
+
+#endif // !defined(_MSC_VER)
+
+//-----------------------------------------------------------------------------
+// Block read - if your platform needs to do endian-swapping or can only
+// handle aligned reads, do the conversion here
+
+FORCE_INLINE uint32_t getblock32 ( const uint32_t * p, int i )
+{
+  return p[i];
+}
+
+FORCE_INLINE uint64_t getblock64 ( const uint64_t * p, int i )
+{
+  return p[i];
+}
+
+//-----------------------------------------------------------------------------
+// Finalization mix - force all bits of a hash block to avalanche
+
+FORCE_INLINE uint32_t fmix32 ( uint32_t h )
+{
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
+
+  return h;
+}
+
+//----------
+
+FORCE_INLINE uint64_t fmix64 ( uint64_t k )
+{
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xff51afd7ed558ccd);
+  k ^= k >> 33;
+  k *= BIG_CONSTANT(0xc4ceb9fe1a85ec53);
+  k ^= k >> 33;
+
+  return k;
+}
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_32 ( const void * key, int len,
+                          uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 4;
+
+  uint32_t h1 = seed;
+
+  const uint32_t c1 = 0xcc9e2d51;
+  const uint32_t c2 = 0x1b873593;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*4);
+
+  for(int i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock32(blocks,i);
+
+    k1 *= c1;
+    k1 = ROTL32(k1,15);
+    k1 *= c2;
+    
+    h1 ^= k1;
+    h1 = ROTL32(h1,13); 
+    h1 = h1*5+0xe6546b64;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*4);
+
+  uint32_t k1 = 0;
+
+  switch(len & 3)
+  {
+  case 3: k1 ^= tail[2] << 16;
+  case 2: k1 ^= tail[1] << 8;
+  case 1: k1 ^= tail[0];
+          k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len;
+
+  h1 = fmix32(h1);
+
+  *(uint32_t*)out = h1;
+} 
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_128 ( const void * key, const int len,
+                           uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+
+  uint32_t h1 = seed;
+  uint32_t h2 = seed;
+  uint32_t h3 = seed;
+  uint32_t h4 = seed;
+
+  const uint32_t c1 = 0x239b961b; 
+  const uint32_t c2 = 0xab0e9789;
+  const uint32_t c3 = 0x38b34ae5; 
+  const uint32_t c4 = 0xa1e38b93;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*16);
+
+  for(int i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock32(blocks,i*4+0);
+    uint32_t k2 = getblock32(blocks,i*4+1);
+    uint32_t k3 = getblock32(blocks,i*4+2);
+    uint32_t k4 = getblock32(blocks,i*4+3);
+
+    k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL32(h1,19); h1 += h2; h1 = h1*5+0x561ccd1b;
+
+    k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+    h2 = ROTL32(h2,17); h2 += h3; h2 = h2*5+0x0bcaa747;
+
+    k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+    h3 = ROTL32(h3,15); h3 += h4; h3 = h3*5+0x96cd1c35;
+
+    k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+    h4 = ROTL32(h4,13); h4 += h1; h4 = h4*5+0x32ac3b17;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint32_t k1 = 0;
+  uint32_t k2 = 0;
+  uint32_t k3 = 0;
+  uint32_t k4 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k4 ^= tail[14] << 16;
+  case 14: k4 ^= tail[13] << 8;
+  case 13: k4 ^= tail[12] << 0;
+           k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+
+  case 12: k3 ^= tail[11] << 24;
+  case 11: k3 ^= tail[10] << 16;
+  case 10: k3 ^= tail[ 9] << 8;
+  case  9: k3 ^= tail[ 8] << 0;
+           k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+
+  case  8: k2 ^= tail[ 7] << 24;
+  case  7: k2 ^= tail[ 6] << 16;
+  case  6: k2 ^= tail[ 5] << 8;
+  case  5: k2 ^= tail[ 4] << 0;
+           k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+
+  case  4: k1 ^= tail[ 3] << 24;
+  case  3: k1 ^= tail[ 2] << 16;
+  case  2: k1 ^= tail[ 1] << 8;
+  case  1: k1 ^= tail[ 0] << 0;
+           k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len; h3 ^= len; h4 ^= len;
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  h1 = fmix32(h1);
+  h2 = fmix32(h2);
+  h3 = fmix32(h3);
+  h4 = fmix32(h4);
+
+  h1 += h2; h1 += h3; h1 += h4;
+  h2 += h1; h3 += h1; h4 += h1;
+
+  ((uint32_t*)out)[0] = h1;
+  ((uint32_t*)out)[1] = h2;
+  ((uint32_t*)out)[2] = h3;
+  ((uint32_t*)out)[3] = h4;
+}
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x64_128 ( const void * key, const int len,
+                           const uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 16;
+
+  uint64_t h1 = seed;
+  uint64_t h2 = seed;
+
+  const uint64_t c1 = BIG_CONSTANT(0x87c37b91114253d5);
+  const uint64_t c2 = BIG_CONSTANT(0x4cf5ad432745937f);
+
+  //----------
+  // body
+
+  const uint64_t * blocks = (const uint64_t *)(data);
+
+  for(int i = 0; i < nblocks; i++)
+  {
+    uint64_t k1 = getblock64(blocks,i*2+0);
+    uint64_t k2 = getblock64(blocks,i*2+1);
+
+    k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+
+    h1 = ROTL64(h1,27); h1 += h2; h1 = h1*5+0x52dce729;
+
+    k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+    h2 = ROTL64(h2,31); h2 += h1; h2 = h2*5+0x38495ab5;
+  }
+
+  //----------
+  // tail
+
+  const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+
+  uint64_t k1 = 0;
+  uint64_t k2 = 0;
+
+  switch(len & 15)
+  {
+  case 15: k2 ^= ((uint64_t)tail[14]) << 48;
+  case 14: k2 ^= ((uint64_t)tail[13]) << 40;
+  case 13: k2 ^= ((uint64_t)tail[12]) << 32;
+  case 12: k2 ^= ((uint64_t)tail[11]) << 24;
+  case 11: k2 ^= ((uint64_t)tail[10]) << 16;
+  case 10: k2 ^= ((uint64_t)tail[ 9]) << 8;
+  case  9: k2 ^= ((uint64_t)tail[ 8]) << 0;
+           k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+
+  case  8: k1 ^= ((uint64_t)tail[ 7]) << 56;
+  case  7: k1 ^= ((uint64_t)tail[ 6]) << 48;
+  case  6: k1 ^= ((uint64_t)tail[ 5]) << 40;
+  case  5: k1 ^= ((uint64_t)tail[ 4]) << 32;
+  case  4: k1 ^= ((uint64_t)tail[ 3]) << 24;
+  case  3: k1 ^= ((uint64_t)tail[ 2]) << 16;
+  case  2: k1 ^= ((uint64_t)tail[ 1]) << 8;
+  case  1: k1 ^= ((uint64_t)tail[ 0]) << 0;
+           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+  };
+
+  //----------
+  // finalization
+
+  h1 ^= len; h2 ^= len;
+
+  h1 += h2;
+  h2 += h1;
+
+  h1 = fmix64(h1);
+  h2 = fmix64(h2);
+
+  h1 += h2;
+  h2 += h1;
+
+  ((uint64_t*)out)[0] = h1;
+  ((uint64_t*)out)[1] = h2;
+}
+
+//-----------------------------------------------------------------------------
+

--- a/extensions/ringmurmurhash/libmurmurhash/MurmurHash3.h
+++ b/extensions/ringmurmurhash/libmurmurhash/MurmurHash3.h
@@ -1,0 +1,37 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+#ifndef _MURMURHASH3_H_
+#define _MURMURHASH3_H_
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER) && (_MSC_VER < 1600)
+
+typedef unsigned char uint8_t;
+typedef unsigned int uint32_t;
+typedef unsigned __int64 uint64_t;
+
+// Other compilers
+
+#else	// defined(_MSC_VER)
+
+#include <stdint.h>
+
+#endif // !defined(_MSC_VER)
+
+//-----------------------------------------------------------------------------
+
+void MurmurHash3_x86_32  ( const void * key, int len, uint32_t seed, void * out );
+
+void MurmurHash3_x86_128 ( const void * key, int len, uint32_t seed, void * out );
+
+void MurmurHash3_x64_128 ( const void * key, int len, uint32_t seed, void * out );
+
+//-----------------------------------------------------------------------------
+
+#endif // _MURMURHASH3_H_

--- a/extensions/ringmurmurhash/libmurmurhash/README.md
+++ b/extensions/ringmurmurhash/libmurmurhash/README.md
@@ -1,0 +1,16 @@
+## [SMHasher](https://github.com/aappleby/smhasher/wiki) is a test suite designed to test the distribution, collision, and performance properties of non-cryptographic hash functions.
+
+This is the home for the [MurmurHash](https://github.com/aappleby/smhasher/tree/master/src) family of hash functions along with the [SMHasher](https://github.com/aappleby/smhasher/tree/master/src) test suite used to verify them. SMHasher is released under the MIT license. All MurmurHash versions are public domain software, and the author disclaims all copyright to their code.
+
+SMHasher is a test suite designed to test the distribution, collision, and performance properties of non-cryptographic hash functions - it aims to be the [DieHarder](http://www.phy.duke.edu/~rgb/General/dieharder.php) of hash testing, and does a pretty good job of finding flaws with a number of popular hashes.
+
+The SMHasher suite also includes [MurmurHash3](https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp), which is the latest version in the series of MurmurHash functions - the new version is faster, more robust, and its variants can produce 32- and 128-bit hash values efficiently on both x86 and x64 platforms.
+
+
+## Updates
+
+### 1/8/2016
+
+Woo, we're on Github! I've been putting off the migration for a few, uh, years or so, but hopefully Github won't be shutting down any time soon so I don't have to move things again. MurmurHash is still used all over the place, SMHasher is still the defacto hash function test suite, and there are all sorts of interesting new hash functions out there that improve bulk hashing speed and use new shiny hardware instructions for AES and whatnot. Interesting times. :)
+
+I've copied the few wiki pages from code.google.com/p/smhasher to this wiki, though I haven't reformatted them to Markdown yet. The MurmurHash page on Wikipedia should also be linking here now as well. Feel free to send me pull requests.

--- a/extensions/ringmurmurhash/murmurhashlib.ring
+++ b/extensions/ringmurmurhash/murmurhashlib.ring
@@ -1,0 +1,7 @@
+if iswindows()
+	LoadLib("ring_murmurhash.dll")
+but ismacosx()
+	LoadLib("libring_murmurhash.dylib")
+else
+	LoadLib("libring_murmurhash.so")
+ok

--- a/extensions/ringmurmurhash/ring_murmurhash.c
+++ b/extensions/ringmurmurhash/ring_murmurhash.c
@@ -15,6 +15,11 @@ RING_API void ringlib_init(RingState *pRingState)
     ring_vm_funcregister("murmurhash64b", ring_murmurhash64b);
     ring_vm_funcregister("murmurhash_neutral2", ring_murmurhash_neutral2);
     ring_vm_funcregister("murmurhash_aligned2", ring_murmurhash_aligned2);
+
+    /* MurmurHash3 functions */
+    ring_vm_funcregister("murmurhash3_x86_32", ring_murmurhash3_x86_32);
+    ring_vm_funcregister("murmurhash3_x86_128", ring_murmurhash3_x86_128);
+    ring_vm_funcregister("murmurhash3_x64_128", ring_murmurhash3_x64_128);
 }
 
 int is_bool(int tmp)
@@ -397,4 +402,165 @@ void ring_murmurhash_aligned2(void *pPointer)
     out = MurmurHashAligned2(key, keylen, seed);
 
     MH_RETURN_INT(out, ret_type);
+}
+
+/* MurmurHash3 functions */
+void ring_murmurhash3_x86_32(void *pPointer)
+{
+    char *key = NULL;
+    int keylen;
+    int seed = 0;
+    uint32_t out[1];
+    int ret_type = 0;
+
+    if (RING_API_PARACOUNT < 2 || RING_API_PARACOUNT > 3) {
+        RING_API_ERROR(RING_API_MISS2PARA);
+        return ;
+    }
+
+    if (!RING_API_ISSTRING(1)) {
+        RING_API_ERROR("murmurhash3_x86_32 expects the first parameter to be a string");
+        return;
+    }
+
+    if (!RING_API_ISNUMBER(2)) {
+        RING_API_ERROR("murmurhash3_x86_32 expects the first parameter to be an integer");
+        return;
+    }
+
+    key = RING_API_GETSTRING(1);
+    keylen = strlen(key);
+    seed = RING_API_GETNUMBER(2);
+
+    if (RING_API_PARACOUNT == 3) {
+        if (RING_API_ISNUMBER(3)) {
+            ret_type = RING_API_GETNUMBER(3);
+            if (!is_bool(ret_type)) {
+                RING_API_ERROR("Third parameter should be boolean value\n");
+            }
+        } else {
+            RING_API_ERROR("murmurhash3_x86_32 expects the third parameter to be an integer\n");
+        }
+    }
+
+    MurmurHash3_x86_32(key, keylen, seed, out);
+
+    MH_RETURN_INT(out[0], ret_type);
+}
+
+
+void ring_murmurhash3_x86_128(void *pPointer)
+{
+    char *key = NULL;
+    int keylen;
+    int seed = 0;
+    uint32_t out[4];
+    int ret_type = 0;
+
+    List *tmp_list, *ret_val;
+
+    if (RING_API_PARACOUNT < 2 || RING_API_PARACOUNT > 3) {
+        RING_API_ERROR(RING_API_MISS2PARA);
+        return ;
+    }
+
+    if (!RING_API_ISSTRING(1)) {
+        RING_API_ERROR("murmurhash3_x86_128 expects the first parameter to be a string");
+        return;
+    }
+
+    if (!RING_API_ISNUMBER(2)) {
+        RING_API_ERROR("murmurhash3_x86_128 expects the first parameter to be an integer");
+        return;
+    }
+
+    key = RING_API_GETSTRING(1);
+    keylen = strlen(key);
+    seed = RING_API_GETNUMBER(2);
+
+    if (RING_API_PARACOUNT == 3) {
+        if (RING_API_ISNUMBER(3)) {
+            ret_type = RING_API_GETNUMBER(3);
+            if (!is_bool(ret_type)) {
+                RING_API_ERROR("Third parameter should be boolean value\n");
+            }
+        } else {
+            RING_API_ERROR("murmurhash3_x86_128 expects the third parameter to be an integer\n");
+        }
+    }
+
+    MurmurHash3_x86_128(key, keylen, seed, out);
+
+    ret_val = RING_API_NEWLIST;
+    tmp_list = ring_list_newlist_gc(((VM *)pPointer)->pRingState, ret_val);
+
+    for (int i = 0; i < 4; i++) {
+        if (ret_type) {
+            char tmp[50];
+            INT2HEX(tmp, out[i]);
+            ring_list_addstring2(tmp_list, (char*) tmp, strlen((char *) tmp));
+        } else {
+            ring_list_addint(tmp_list, out[i]);
+        }
+    }
+
+    RING_API_RETLIST(ret_val);
+}
+
+void ring_murmurhash3_x64_128(void *pPointer)
+{
+    char *key = NULL;
+    int keylen;
+    int seed = 0;
+    uint64_t out[2];
+    int ret_type = 0;
+
+    List *tmp_list, *ret_val;
+
+    if (RING_API_PARACOUNT < 2 || RING_API_PARACOUNT > 3) {
+        RING_API_ERROR(RING_API_MISS2PARA);
+        return ;
+    }
+
+    if (!RING_API_ISSTRING(1)) {
+        RING_API_ERROR("murmurhash3_x64_128 expects the first parameter to be a string");
+        return;
+    }
+
+    if (!RING_API_ISNUMBER(2)) {
+        RING_API_ERROR("murmurhash3_x64_128 expects the first parameter to be an integer");
+        return;
+    }
+
+    key = RING_API_GETSTRING(1);
+    keylen = strlen(key);
+    seed = RING_API_GETNUMBER(2);
+
+    if (RING_API_PARACOUNT == 3) {
+        if (RING_API_ISNUMBER(3)) {
+            ret_type = RING_API_GETNUMBER(3);
+            if (!is_bool(ret_type)) {
+                RING_API_ERROR("Third parameter should be boolean value\n");
+            }
+        } else {
+            RING_API_ERROR("murmurhash3_x64_128 expects the third parameter to be an integer\n");
+        }
+    }
+
+    MurmurHash3_x64_128(key, keylen, seed, out);
+
+    ret_val = RING_API_NEWLIST;
+    tmp_list = ring_list_newlist_gc(((VM *)pPointer)->pRingState, ret_val);
+
+    for (int i = 0; i < 2; i++) {
+        if (ret_type) {
+            char tmp[50];
+            LONG2HEX(tmp, out[i]);
+            ring_list_addstring2(tmp_list, (char*) tmp, strlen((char *) tmp));
+        } else {
+            ring_list_addint(tmp_list, out[i]);
+        }
+    }
+
+    RING_API_RETLIST(ret_val);
 }

--- a/extensions/ringmurmurhash/ring_murmurhash.c
+++ b/extensions/ringmurmurhash/ring_murmurhash.c
@@ -22,42 +22,6 @@ RING_API void ringlib_init(RingState *pRingState)
     ring_vm_funcregister("murmurhash3_x64_128", ring_murmurhash3_x64_128);
 }
 
-int is_bool(int tmp)
-{
-    if (
-        tmp == 1 ||
-        tmp == 0
-    ) {
-        return 1;
-    } else {
-        return 0;
-    }
-}
-
-#define INT2HEX(dest, val) sprintf(dest, "%x", val)
-
-#define LONG2HEX(dest, val) sprintf(dest, "%lx", val)
-
-#define MH_RETURN_INT(ret_val, ret_type) { \
-    if (ret_type) { \
-        char tmp[50]; \
-        INT2HEX(tmp, ret_val); \
-        RING_API_RETSTRING(tmp); return; \
-    } else { \
-        RING_API_RETNUMBER(ret_val); return; \
-    } \
-}
-
-#define MH_RETURN_LONG(ret_val, ret_type) { \
-    if (ret_type) { \
-        char tmp[50]; \
-        LONG2HEX(tmp, ret_val); \
-        RING_API_RETSTRING(tmp); return; \
-    } else { \
-        RING_API_RETNUMBER(ret_val); return; \
-    } \
-}
-
 /* MurmurHash1 functions */
 void ring_murmurhash1(void *pPointer)
 {

--- a/extensions/ringmurmurhash/ring_murmurhash.c
+++ b/extensions/ringmurmurhash/ring_murmurhash.c
@@ -4,8 +4,17 @@
 
 RING_API void ringlib_init(RingState *pRingState)
 {
+    /* MurmurHash1 functions */
     ring_vm_funcregister("murmurhash1", ring_murmurhash1);
     ring_vm_funcregister("murmurhash1_aligned", ring_murmurhash1_aligned);
+
+    /* MurmurHash2 functions */
+    ring_vm_funcregister("murmurhash2", ring_murmurhash2);
+    ring_vm_funcregister("murmurhash2a", ring_murmurhash2a);
+    ring_vm_funcregister("murmurhash64a", ring_murmurhash64a);
+    ring_vm_funcregister("murmurhash64b", ring_murmurhash64b);
+    ring_vm_funcregister("murmurhash_neutral2", ring_murmurhash_neutral2);
+    ring_vm_funcregister("murmurhash_aligned2", ring_murmurhash_aligned2);
 }
 
 int is_bool(int tmp)
@@ -20,9 +29,21 @@ int is_bool(int tmp)
     }
 }
 
-#define LONG2HEX(dest, val) sprintf(dest, "%x", val)
+#define INT2HEX(dest, val) sprintf(dest, "%x", val)
 
-#define MH_RETURN(ret_val, ret_type) { \
+#define LONG2HEX(dest, val) sprintf(dest, "%lx", val)
+
+#define MH_RETURN_INT(ret_val, ret_type) { \
+    if (ret_type) { \
+        char tmp[50]; \
+        INT2HEX(tmp, ret_val); \
+        RING_API_RETSTRING(tmp); return; \
+    } else { \
+        RING_API_RETNUMBER(ret_val); return; \
+    } \
+}
+
+#define MH_RETURN_LONG(ret_val, ret_type) { \
     if (ret_type) { \
         char tmp[50]; \
         LONG2HEX(tmp, ret_val); \
@@ -32,7 +53,7 @@ int is_bool(int tmp)
     } \
 }
 
-
+/* MurmurHash1 functions */
 void ring_murmurhash1(void *pPointer)
 {
     char *key = NULL;
@@ -73,7 +94,7 @@ void ring_murmurhash1(void *pPointer)
 
     out = MurmurHash1(key, keylen, seed);
 
-    MH_RETURN(out, ret_type);
+    MH_RETURN_INT(out, ret_type);
 }
 
 void ring_murmurhash1_aligned(void *pPointer)
@@ -116,5 +137,264 @@ void ring_murmurhash1_aligned(void *pPointer)
 
     out = MurmurHash1Aligned(key, keylen, seed);
 
-    MH_RETURN(out, ret_type);
+    MH_RETURN_INT(out, ret_type);
+}
+
+/* MurmurHash2 functions */
+void ring_murmurhash2(void *pPointer)
+{
+    char *key = NULL;
+    int keylen;
+    int seed = 0;
+    uint32_t out;
+    int ret_type = 0;
+
+    if (RING_API_PARACOUNT < 2 || RING_API_PARACOUNT > 3) {
+		RING_API_ERROR(RING_API_MISS2PARA);
+		return ;
+	}
+
+    if (!RING_API_ISSTRING(1)) {
+        RING_API_ERROR("murmurhash2 expects the first parameter to be a string");
+        return;
+    }
+
+    if (!RING_API_ISNUMBER(2)) {
+        RING_API_ERROR("murmurhash2 expects the first parameter to be an integer");
+        return;
+    }
+
+    key = RING_API_GETSTRING(1);
+    keylen = strlen(key);
+    seed = RING_API_GETNUMBER(2);
+
+    if (RING_API_PARACOUNT == 3) {
+        if (RING_API_ISNUMBER(3)) {
+            ret_type = RING_API_GETNUMBER(3);
+            if (!is_bool(ret_type)) {
+                RING_API_ERROR("Third parameter should be boolean value\n");
+            }
+        } else {
+            RING_API_ERROR("murmurhash2 expects the third parameter to be an integer\n");
+        }
+    }
+
+    out = MurmurHash2(key, keylen, seed);
+
+    MH_RETURN_INT(out, ret_type);
+}
+
+void ring_murmurhash2a(void *pPointer)
+{
+    char *key = NULL;
+    int keylen;
+    int seed = 0;
+    uint32_t out;
+    int ret_type = 0;
+
+    if (RING_API_PARACOUNT < 2 || RING_API_PARACOUNT > 3) {
+		RING_API_ERROR(RING_API_MISS2PARA);
+		return ;
+	}
+
+    if (!RING_API_ISSTRING(1)) {
+        RING_API_ERROR("murmurhash2a expects the first parameter to be a string");
+        return;
+    }
+
+    if (!RING_API_ISNUMBER(2)) {
+        RING_API_ERROR("murmurhash2a expects the first parameter to be an integer");
+        return;
+    }
+
+    key = RING_API_GETSTRING(1);
+    keylen = strlen(key);
+    seed = RING_API_GETNUMBER(2);
+
+    if (RING_API_PARACOUNT == 3) {
+        if (RING_API_ISNUMBER(3)) {
+            ret_type = RING_API_GETNUMBER(3);
+            if (!is_bool(ret_type)) {
+                RING_API_ERROR("Third parameter should be boolean value\n");
+            }
+        } else {
+            RING_API_ERROR("murmurhash2a expects the third parameter to be an integer\n");
+        }
+    }
+
+    out = MurmurHash2A(key, keylen, seed);
+
+    MH_RETURN_INT(out, ret_type);
+}
+
+void ring_murmurhash64a(void *pPointer)
+{
+    char *key = NULL;
+    int keylen;
+    int seed = 0;
+    uint64_t out;
+    int ret_type = 0;
+
+    if (RING_API_PARACOUNT < 2 || RING_API_PARACOUNT > 3) {
+		RING_API_ERROR(RING_API_MISS2PARA);
+		return ;
+	}
+
+    if (!RING_API_ISSTRING(1)) {
+        RING_API_ERROR("murmurhash64a expects the first parameter to be a string");
+        return;
+    }
+
+    if (!RING_API_ISNUMBER(2)) {
+        RING_API_ERROR("murmurhash64a expects the first parameter to be an integer");
+        return;
+    }
+
+    key = RING_API_GETSTRING(1);
+    keylen = strlen(key);
+    seed = RING_API_GETNUMBER(2);
+
+    if (RING_API_PARACOUNT == 3) {
+        if (RING_API_ISNUMBER(3)) {
+            ret_type = RING_API_GETNUMBER(3);
+            if (!is_bool(ret_type)) {
+                RING_API_ERROR("Third parameter should be boolean value\n");
+            }
+        } else {
+            RING_API_ERROR("murmurhash64a expects the third parameter to be an integer\n");
+        }
+    }
+
+    out = MurmurHash64A(key, keylen, seed);
+
+    MH_RETURN_LONG(out, ret_type);
+}
+
+void ring_murmurhash64b(void *pPointer)
+{
+    char *key = NULL;
+    int keylen;
+    int seed = 0;
+    uint64_t out;
+    int ret_type = 0;
+
+    if (RING_API_PARACOUNT < 2 || RING_API_PARACOUNT > 3) {
+        RING_API_ERROR(RING_API_MISS2PARA);
+        return ;
+    }
+
+    if (!RING_API_ISSTRING(1)) {
+        RING_API_ERROR("murmurhash64b expects the first parameter to be a string");
+        return;
+    }
+
+    if (!RING_API_ISNUMBER(2)) {
+        RING_API_ERROR("murmurhash64b expects the first parameter to be an integer");
+        return;
+    }
+
+    key = RING_API_GETSTRING(1);
+    keylen = strlen(key);
+    seed = RING_API_GETNUMBER(2);
+
+    if (RING_API_PARACOUNT == 3) {
+        if (RING_API_ISNUMBER(3)) {
+            ret_type = RING_API_GETNUMBER(3);
+            if (!is_bool(ret_type)) {
+                RING_API_ERROR("Third parameter should be boolean value\n");
+            }
+        } else {
+            RING_API_ERROR("murmurhash64b expects the third parameter to be an integer\n");
+        }
+    }
+
+    out = MurmurHash64B(key, keylen, seed);
+
+    MH_RETURN_LONG(out, ret_type);
+}
+
+void ring_murmurhash_neutral2(void *pPointer)
+{
+    char *key = NULL;
+    int keylen;
+    int seed = 0;
+    uint32_t out;
+    int ret_type = 0;
+
+    if (RING_API_PARACOUNT < 2 || RING_API_PARACOUNT > 3) {
+        RING_API_ERROR(RING_API_MISS2PARA);
+        return ;
+    }
+
+    if (!RING_API_ISSTRING(1)) {
+        RING_API_ERROR("murmurhash_neutral2 expects the first parameter to be a string");
+        return;
+    }
+
+    if (!RING_API_ISNUMBER(2)) {
+        RING_API_ERROR("murmurhash_neutral2 expects the first parameter to be an integer");
+        return;
+    }
+
+    key = RING_API_GETSTRING(1);
+    keylen = strlen(key);
+    seed = RING_API_GETNUMBER(2);
+
+    if (RING_API_PARACOUNT == 3) {
+        if (RING_API_ISNUMBER(3)) {
+            ret_type = RING_API_GETNUMBER(3);
+            if (!is_bool(ret_type)) {
+                RING_API_ERROR("Third parameter should be boolean value\n");
+            }
+        } else {
+            RING_API_ERROR("murmurhash_neutral2 expects the third parameter to be an integer\n");
+        }
+    }
+
+    out = MurmurHashNeutral2(key, keylen, seed);
+
+    MH_RETURN_INT(out, ret_type);
+}
+
+void ring_murmurhash_aligned2(void *pPointer)
+{
+    char *key = NULL;
+    int keylen;
+    int seed = 0;
+    uint32_t out;
+    int ret_type = 0;
+
+    if (RING_API_PARACOUNT < 2 || RING_API_PARACOUNT > 3) {
+        RING_API_ERROR(RING_API_MISS2PARA);
+        return ;
+    }
+
+    if (!RING_API_ISSTRING(1)) {
+        RING_API_ERROR("murmurhash_aligned2 expects the first parameter to be a string");
+        return;
+    }
+
+    if (!RING_API_ISNUMBER(2)) {
+        RING_API_ERROR("murmurhash_aligned2 expects the first parameter to be an integer");
+        return;
+    }
+
+    key = RING_API_GETSTRING(1);
+    keylen = strlen(key);
+    seed = RING_API_GETNUMBER(2);
+
+    if (RING_API_PARACOUNT == 3) {
+        if (RING_API_ISNUMBER(3)) {
+            ret_type = RING_API_GETNUMBER(3);
+            if (!is_bool(ret_type)) {
+                RING_API_ERROR("Third parameter should be boolean value\n");
+            }
+        } else {
+            RING_API_ERROR("murmurhash_aligned2 expects the third parameter to be an integer\n");
+        }
+    }
+
+    out = MurmurHashAligned2(key, keylen, seed);
+
+    MH_RETURN_INT(out, ret_type);
 }

--- a/extensions/ringmurmurhash/ring_murmurhash.c
+++ b/extensions/ringmurmurhash/ring_murmurhash.c
@@ -8,15 +8,27 @@ RING_API void ringlib_init(RingState *pRingState)
     ring_vm_funcregister("murmurhash1_aligned", ring_murmurhash1_aligned);
 }
 
+int is_bool(int tmp)
+{
+    if (
+        tmp == 1 ||
+        tmp == 0
+    ) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
 #define LONG2HEX(dest, val) sprintf(dest, "%x", val)
 
 #define MH_RETURN(ret_val, ret_type) { \
     if (ret_type) { \
         char tmp[50]; \
         LONG2HEX(tmp, ret_val); \
-        RING_API_RETSTRING(tmp); \
+        RING_API_RETSTRING(tmp); return; \
     } else { \
-        RING_API_RETNUMBER(ret_val); \
+        RING_API_RETNUMBER(ret_val); return; \
     } \
 }
 
@@ -27,19 +39,20 @@ void ring_murmurhash1(void *pPointer)
     int keylen;
     int seed = 0;
     uint32_t out;
+    int ret_type = 0;
 
-    if (RING_API_PARACOUNT != 2) {
+    if (RING_API_PARACOUNT < 2 || RING_API_PARACOUNT > 3) {
 		RING_API_ERROR(RING_API_MISS2PARA);
 		return ;
 	}
 
     if (!RING_API_ISSTRING(1)) {
-        RING_API_ERROR("murmurhash1 expects the first parameter to be a string");
+        RING_API_ERROR("murmurhash1 expects the first parameter to be a string\n");
         return;
     }
 
     if (!RING_API_ISNUMBER(2)) {
-        RING_API_ERROR("murmurhash1 expects the first parameter to be an integer");
+        RING_API_ERROR("murmurhash1 expects the first parameter to be an integer\n");
         return;
     }
 
@@ -47,10 +60,20 @@ void ring_murmurhash1(void *pPointer)
     keylen = strlen(key);
     seed = RING_API_GETNUMBER(2);
 
+    if (RING_API_PARACOUNT == 3) {
+        if (RING_API_ISNUMBER(3)) {
+            ret_type = RING_API_GETNUMBER(3);
+            if (!is_bool(ret_type)) {
+                RING_API_ERROR("Third parameter should be boolean value\n");
+            }
+        } else {
+            RING_API_ERROR("murmurhash1 expects the third parameter to be an integer\n");
+        }
+    }
+
     out = MurmurHash1(key, keylen, seed);
 
-    MH_RETURN(out, 0);
-    return;
+    MH_RETURN(out, ret_type);
 }
 
 void ring_murmurhash1_aligned(void *pPointer)
@@ -59,19 +82,20 @@ void ring_murmurhash1_aligned(void *pPointer)
     int keylen;
     int seed = 0;
     uint32_t out;
+    int ret_type = 0;
 
-    if (RING_API_PARACOUNT != 2) {
+    if (RING_API_PARACOUNT < 2 || RING_API_PARACOUNT > 3) {
 		RING_API_ERROR(RING_API_MISS2PARA);
 		return ;
 	}
 
     if (!RING_API_ISSTRING(1)) {
-        RING_API_ERROR("murmurhash1 expects the first parameter to be a string");
+        RING_API_ERROR("murmurhash1_aligned expects the first parameter to be a string");
         return;
     }
 
     if (!RING_API_ISNUMBER(2)) {
-        RING_API_ERROR("murmurhash1 expects the first parameter to be an integer");
+        RING_API_ERROR("murmurhash1_aligned expects the first parameter to be an integer");
         return;
     }
 
@@ -79,8 +103,18 @@ void ring_murmurhash1_aligned(void *pPointer)
     keylen = strlen(key);
     seed = RING_API_GETNUMBER(2);
 
+    if (RING_API_PARACOUNT == 3) {
+        if (RING_API_ISNUMBER(3)) {
+            ret_type = RING_API_GETNUMBER(3);
+            if (!is_bool(ret_type)) {
+                RING_API_ERROR("Third parameter should be boolean value\n");
+            }
+        } else {
+            RING_API_ERROR("murmurhash1_aligned expects the third parameter to be an integer\n");
+        }
+    }
+
     out = MurmurHash1Aligned(key, keylen, seed);
 
-    MH_RETURN(out, 0);
-    return;
+    MH_RETURN(out, ret_type);
 }

--- a/extensions/ringmurmurhash/ring_murmurhash.c
+++ b/extensions/ringmurmurhash/ring_murmurhash.c
@@ -1,0 +1,8 @@
+
+#include "ring_murmurhash.h"
+
+
+RING_API void ringlib_init(RingState *pRingState)
+{
+
+}

--- a/extensions/ringmurmurhash/ring_murmurhash.c
+++ b/extensions/ringmurmurhash/ring_murmurhash.c
@@ -4,5 +4,83 @@
 
 RING_API void ringlib_init(RingState *pRingState)
 {
+    ring_vm_funcregister("murmurhash1", ring_murmurhash1);
+    ring_vm_funcregister("murmurhash1_aligned", ring_murmurhash1_aligned);
+}
 
+#define LONG2HEX(dest, val) sprintf(dest, "%x", val)
+
+#define MH_RETURN(ret_val, ret_type) { \
+    if (ret_type) { \
+        char tmp[50]; \
+        LONG2HEX(tmp, ret_val); \
+        RING_API_RETSTRING(tmp); \
+    } else { \
+        RING_API_RETNUMBER(ret_val); \
+    } \
+}
+
+
+void ring_murmurhash1(void *pPointer)
+{
+    char *key = NULL;
+    int keylen;
+    int seed = 0;
+    uint32_t out;
+
+    if (RING_API_PARACOUNT != 2) {
+		RING_API_ERROR(RING_API_MISS2PARA);
+		return ;
+	}
+
+    if (!RING_API_ISSTRING(1)) {
+        RING_API_ERROR("murmurhash1 expects the first parameter to be a string");
+        return;
+    }
+
+    if (!RING_API_ISNUMBER(2)) {
+        RING_API_ERROR("murmurhash1 expects the first parameter to be an integer");
+        return;
+    }
+
+    key = RING_API_GETSTRING(1);
+    keylen = strlen(key);
+    seed = RING_API_GETNUMBER(2);
+
+    out = MurmurHash1(key, keylen, seed);
+
+    MH_RETURN(out, 0);
+    return;
+}
+
+void ring_murmurhash1_aligned(void *pPointer)
+{
+    char *key = NULL;
+    int keylen;
+    int seed = 0;
+    uint32_t out;
+
+    if (RING_API_PARACOUNT != 2) {
+		RING_API_ERROR(RING_API_MISS2PARA);
+		return ;
+	}
+
+    if (!RING_API_ISSTRING(1)) {
+        RING_API_ERROR("murmurhash1 expects the first parameter to be a string");
+        return;
+    }
+
+    if (!RING_API_ISNUMBER(2)) {
+        RING_API_ERROR("murmurhash1 expects the first parameter to be an integer");
+        return;
+    }
+
+    key = RING_API_GETSTRING(1);
+    keylen = strlen(key);
+    seed = RING_API_GETNUMBER(2);
+
+    out = MurmurHash1Aligned(key, keylen, seed);
+
+    MH_RETURN(out, 0);
+    return;
 }

--- a/extensions/ringmurmurhash/ring_murmurhash.h
+++ b/extensions/ringmurmurhash/ring_murmurhash.h
@@ -4,3 +4,7 @@
 #include "MurmurHash1.h"
 #include "MurmurHash2.h"
 #include "MurmurHash3.h"
+
+/* Murmur Hash 1 functions */
+void ring_murmurhash1(void *pPointer);
+void ring_murmurhash1_aligned(void *pPointer);

--- a/extensions/ringmurmurhash/ring_murmurhash.h
+++ b/extensions/ringmurmurhash/ring_murmurhash.h
@@ -16,3 +16,8 @@ void ring_murmurhash64a(void *pPointer);
 void ring_murmurhash64b(void *pPointer);
 void ring_murmurhash_neutral2(void *pPointer);
 void ring_murmurhash_aligned2(void *pPointer);
+
+/* MurmurHash3 functions */
+void ring_murmurhash3_x86_32(void *pPointer);
+void ring_murmurhash3_x86_128(void *pPointer);
+void ring_murmurhash3_x64_128(void *pPointer);

--- a/extensions/ringmurmurhash/ring_murmurhash.h
+++ b/extensions/ringmurmurhash/ring_murmurhash.h
@@ -5,6 +5,42 @@
 #include "MurmurHash2.h"
 #include "MurmurHash3.h"
 
+int is_bool(int tmp)
+{
+    if (
+        tmp == 1 ||
+        tmp == 0
+    ) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+#define INT2HEX(dest, val) sprintf(dest, "%x", val)
+
+#define LONG2HEX(dest, val) sprintf(dest, "%lx", val)
+
+#define MH_RETURN_INT(ret_val, ret_type) { \
+    if (ret_type) { \
+        char tmp[50]; \
+        INT2HEX(tmp, ret_val); \
+        RING_API_RETSTRING(tmp); return; \
+    } else { \
+        RING_API_RETNUMBER(ret_val); return; \
+    } \
+}
+
+#define MH_RETURN_LONG(ret_val, ret_type) { \
+    if (ret_type) { \
+        char tmp[50]; \
+        LONG2HEX(tmp, ret_val); \
+        RING_API_RETSTRING(tmp); return; \
+    } else { \
+        RING_API_RETNUMBER(ret_val); return; \
+    } \
+}
+
 /* MurmurHash1 functions */
 void ring_murmurhash1(void *pPointer);
 void ring_murmurhash1_aligned(void *pPointer);

--- a/extensions/ringmurmurhash/ring_murmurhash.h
+++ b/extensions/ringmurmurhash/ring_murmurhash.h
@@ -1,0 +1,6 @@
+
+#include "ring.h"
+
+#include "MurmurHash1.h"
+#include "MurmurHash2.h"
+#include "MurmurHash3.h"

--- a/extensions/ringmurmurhash/ring_murmurhash.h
+++ b/extensions/ringmurmurhash/ring_murmurhash.h
@@ -5,6 +5,14 @@
 #include "MurmurHash2.h"
 #include "MurmurHash3.h"
 
-/* Murmur Hash 1 functions */
+/* MurmurHash1 functions */
 void ring_murmurhash1(void *pPointer);
 void ring_murmurhash1_aligned(void *pPointer);
+
+/* MurmurHash2 functions */
+void ring_murmurhash2(void *pPointer);
+void ring_murmurhash2a(void *pPointer);
+void ring_murmurhash64a(void *pPointer);
+void ring_murmurhash64b(void *pPointer);
+void ring_murmurhash_neutral2(void *pPointer);
+void ring_murmurhash_aligned2(void *pPointer);

--- a/extensions/ringmurmurhash/tests/murmurhash1.ring
+++ b/extensions/ringmurmurhash/tests/murmurhash1.ring
@@ -1,0 +1,6 @@
+LoadLib("libring_murmurhash.so")
+
+key = "Ring Language"
+
+see "Print '" + key + "' as an integer value '" + murmurhash1(key, 0, 0) + "'" + nl
+see "Print '" + key + "' as a hex value '" + murmurhash1(key, 0, 1) + "'" + nl

--- a/extensions/ringmurmurhash/tests/murmurhash1_aligned.ring
+++ b/extensions/ringmurmurhash/tests/murmurhash1_aligned.ring
@@ -1,0 +1,6 @@
+LoadLib("libring_murmurhash.so")
+
+key = "Ring Language"
+
+see "Print '" + key + "' as an integer value '" + murmurhash1_aligned(key, 0, 0) + "'" + nl
+see "Print '" + key + "' as a hex value '" + murmurhash1_aligned(key, 0, 1) + "'" + nl

--- a/extensions/ringmurmurhash/tests/murmurhash2.ring
+++ b/extensions/ringmurmurhash/tests/murmurhash2.ring
@@ -1,0 +1,6 @@
+LoadLib("libring_murmurhash.so")
+
+key = "Ring Language"
+
+see "Print '" + key + "' as an integer value '" + murmurhash2(key, 0, 0) + "'" + nl
+see "Print '" + key + "' as a hex value '" + murmurhash2(key, 0, 1) + "'" + nl

--- a/extensions/ringmurmurhash/tests/murmurhash2a.ring
+++ b/extensions/ringmurmurhash/tests/murmurhash2a.ring
@@ -1,0 +1,6 @@
+LoadLib("libring_murmurhash.so")
+
+key = "Ring Language"
+
+see "Print '" + key + "' as an integer value '" + murmurhash2a(key, 0, 0) + "'" + nl
+see "Print '" + key + "' as a hex value '" + murmurhash2a(key, 0, 1) + "'" + nl

--- a/extensions/ringmurmurhash/tests/murmurhash3_x64_128.ring
+++ b/extensions/ringmurmurhash/tests/murmurhash3_x64_128.ring
@@ -1,0 +1,6 @@
+LoadLib("libring_murmurhash.so")
+
+key = "Ring Language"
+
+see "Print '" + key + "' as an integer value '" + murmurhash3_x64_128(key, 0, 0) + "'" + nl
+see "Print '" + key + "' as a hex value '" + murmurhash3_x64_128(key, 0, 1) + "'" + nl

--- a/extensions/ringmurmurhash/tests/murmurhash3_x86_128.ring
+++ b/extensions/ringmurmurhash/tests/murmurhash3_x86_128.ring
@@ -1,0 +1,6 @@
+LoadLib("libring_murmurhash.so")
+
+key = "Ring Language"
+
+see "Print '" + key + "' as an integer value '" + murmurhash3_x86_128(key, 0, 0) + "'" + nl
+see "Print '" + key + "' as a hex value '" + murmurhash3_x86_128(key, 0, 1) + "'" + nl

--- a/extensions/ringmurmurhash/tests/murmurhash3_x86_32.ring
+++ b/extensions/ringmurmurhash/tests/murmurhash3_x86_32.ring
@@ -1,0 +1,6 @@
+LoadLib("libring_murmurhash.so")
+
+key = "Ring Language"
+
+see "Print '" + key + "' as an integer value '" + murmurhash3_x86_32(key, 0, 0) + "'" + nl
+see "Print '" + key + "' as a hex value '" + murmurhash3_x86_32(key, 0, 1) + "'" + nl

--- a/extensions/ringmurmurhash/tests/murmurhash64a.ring
+++ b/extensions/ringmurmurhash/tests/murmurhash64a.ring
@@ -1,0 +1,6 @@
+LoadLib("libring_murmurhash.so")
+
+key = "Ring Language"
+
+see "Print '" + key + "' as an integer value '" + murmurhash64a(key, 0, 0) + "'" + nl
+see "Print '" + key + "' as a hex value '" + murmurhash64a(key, 0, 1) + "'" + nl

--- a/extensions/ringmurmurhash/tests/murmurhash64b.ring
+++ b/extensions/ringmurmurhash/tests/murmurhash64b.ring
@@ -1,0 +1,6 @@
+LoadLib("libring_murmurhash.so")
+
+key = "Ring Language"
+
+see "Print '" + key + "' as an integer value '" + murmurhash64b(key, 0, 0) + "'" + nl
+see "Print '" + key + "' as a hex value '" + murmurhash64b(key, 0, 1) + "'" + nl

--- a/extensions/ringmurmurhash/tests/murmurhash_aligned2.ring
+++ b/extensions/ringmurmurhash/tests/murmurhash_aligned2.ring
@@ -1,0 +1,6 @@
+LoadLib("libring_murmurhash.so")
+
+key = "Ring Language"
+
+see "Print '" + key + "' as an integer value '" + murmurhash_aligned2(key, 0, 0) + "'" + nl
+see "Print '" + key + "' as a hex value '" + murmurhash_aligned2(key, 0, 1) + "'" + nl

--- a/extensions/ringmurmurhash/tests/murmurhash_neutral2.ring
+++ b/extensions/ringmurmurhash/tests/murmurhash_neutral2.ring
@@ -1,0 +1,6 @@
+LoadLib("libring_murmurhash.so")
+
+key = "Ring Language"
+
+see "Print '" + key + "' as an integer value '" + murmurhash_neutral2(key, 0, 0) + "'" + nl
+see "Print '" + key + "' as a hex value '" + murmurhash_neutral2(key, 0, 1) + "'" + nl


### PR DESCRIPTION
Implement a full coverage for the Murmur Hash library,

Murmur hash is only used in `openssl` extension with only one function.