### PR TITLE
Support more paths in locatevc.bat

### DIFF
--- a/src/locatevc.bat
+++ b/src/locatevc.bat
@@ -16,6 +16,24 @@ if exist "C:\Program Files\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" (
 	exit /b
 )
 
+if exist "C:\Program Files\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
+	set VSCMD_START_DIR=%cd%
+	call "C:\Program Files\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
+	exit /b
+)
+
+if exist "C:\Program Files\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat" (
+	set VSCMD_START_DIR=%cd%
+	call "C:\Program Files\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
+	exit /b
+)
+
+if exist "C:\Program Files\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat" (
+	set VSCMD_START_DIR=%cd%
+	call "C:\Program Files\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat"
+	exit /b
+)
+
 if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
 	set VSCMD_START_DIR=%cd%
 	call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"


### PR DESCRIPTION
i have a problem that vc 2017 is located in "C:\Program Files\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" i don't know how much common is that but these changes fixed my problem.