### PR TITLE
Fix ring2exe.ring problem with spaces in paths

### DIFF
--- a/ring2exe/ring2exe.ring
+++ b/ring2exe/ring2exe.ring
@@ -128,7 +128,7 @@ func msg cMsg
 func BuildApp cFileName,aOptions
 	msg("Start building the application...")
 	# Generate the Object File 
-		systemSilent(exefolder()+"../bin/ring " + cFileName + " -go -norun")
+		systemSilent('"' + exefolder()+"../bin/ring" + '" ' + cFileName + " -go -norun")
 	# Generate the C Source Code File 
 		cFile = substr(cFileName,".ring","")
 		GenerateCFile(cFile,aOptions)


### PR DESCRIPTION
There is a problem with path resolving in ring2exe when the ring folder path have spaces for example :

`C:\Program Files\ring`

to fix this i just added two " around the ring path i don't know if this is the best way to do it but it works for me