### PR TITLE
Fix crash in ring_vm_numtostring when printing a large double value

### DIFF
--- a/language/src/ring_api.c
+++ b/language/src/ring_api.c
@@ -1660,7 +1660,7 @@ void ring_vmlib_substr ( void *pPointer )
 			nSize2 = RING_API_GETSTRINGSIZE(2) ;
 			cStr3 = ring_string_find2(cStr,nSize,cStr2,nSize2);
 			if ( cStr3 != NULL ) {
-				nNum1 = ((long int) cStr3) - ((long int) cStr) + 1 ;
+				nNum1 = ((long long) cStr3) - ((long long) cStr) + 1 ;
 			} else {
 				nNum1 = 0.0 ;
 			}
@@ -1724,7 +1724,7 @@ void ring_vmlib_substr ( void *pPointer )
 		nMark = 0 ;
 		pString = ring_string_new_gc(((VM *) pPointer)->pRingState,"");
 		while ( cString != NULL ) {
-			nPos = ((long int) cString) - ((long int) cStr) + 1 ;
+			nPos = (unsigned int) (((long long) cString) - ((long long) cStr) + 1) ;
 			/* Add SubString to pString */
 			ring_string_add2_gc(((VM *) pPointer)->pRingState,pString,cStr+nMark,nPos-1-nMark);
 			ring_string_add2_gc(((VM *) pPointer)->pRingState,pString,cStr3,RING_API_GETSTRINGSIZE(3));

--- a/language/src/ring_vmexpr.c
+++ b/language/src/ring_vmexpr.c
@@ -967,12 +967,25 @@ void ring_vm_bitnot ( VM *pVM )
 char * ring_vm_numtostring ( VM *pVM,double nNum1,char *cStr )
 {
 	char cOptions[10]  ;
+	int nNum2 ;
 	if ( nNum1 == (int) nNum1 ) {
 		sprintf( cStr , "%.0f" , nNum1 ) ;
 	}
 	else {
 		sprintf( cOptions , "%s%df" , "%.",pVM->nDecimals ) ;
-		sprintf( cStr , cOptions , nNum1 ) ;
+		/* avoir buffer overrun by using snprint with size=100 since cStr is 100 characters long */
+		nNum2 = snprintf( cStr , 100, cOptions , nNum1 ) ;
+		if (nNum2 < 0)
+			cStr[0] = 0; /* error */
+		else if (nNum2 >= 100)
+		{
+			/* result truncated so print in compact format with a precison of 90 
+			 * which is guaranteed to never overrun our buffer
+			 */
+			nNum2 = snprintf( cStr , 100, "%.90e" , nNum1 ) ;
+			if (nNum2 < 0)
+				cStr[0] = 0; /* error */
+		}
 	}
 	return cStr ;
 }


### PR DESCRIPTION
The function `ring_vm_numtostring` uses `sprintf` on a fixed size `cStr` buffer with a length of 100 bytes.
But if the double value requires more than 99 characters to be printed, then the `sprintf` call will overrun the buffer cStr, causing a crash.

By using `snprintf` instead of sprintf, we avoid the crash since we can handle gracefully the special case of double value requiering more than 99 characters by using in this case the compact double presentation (%e).

Example of crashing program:
```
c = 999999999999999
for i = 1 to 13
  c *= 999999999999999
end

put "c = " + c + nl
```

Crash reproduced on Windows 32-bit and Ubuntu Linux 64-bit.
Below is screenshot of crash of the above program under Ubuntu Linux 64-bit:

![ring_crash_linux_ubuntu](https://user-images.githubusercontent.com/4698669/102544233-ca76b400-40b4-11eb-860d-6bf820f0aaeb.png)


