### PR TITLE
Make str2hex 10x faster and in conformance with standard hexadecimal representation

### DIFF
--- a/language/src/ring_api.c
+++ b/language/src/ring_api.c
@@ -1273,10 +1273,11 @@ void ring_vmlib_string ( void *pPointer )
 
 void ring_vmlib_str2hex ( void *pPointer )
 {
-	char cStr[3]  ;
 	unsigned char *cString  ;
 	int x,nMax  ;
 	char *cString2  ;
+	unsigned char bVal ;
+	static const char cHexChars[] = "0123456789abcdef";
 	if ( RING_API_PARACOUNT != 1 ) {
 		RING_API_ERROR(RING_API_MISS1PARA);
 		return ;
@@ -1290,13 +1291,9 @@ void ring_vmlib_str2hex ( void *pPointer )
 			return ;
 		}
 		for ( x = 1 ; x <= nMax ; x++ ) {
-			sprintf( cStr , "%x" , (unsigned int) cString[x-1] ) ;
-			cString2[(x-1)*2] = cStr[0] ;
-			if ( cStr[1] != '\0' ) {
-				cString2[((x-1)*2)+1] = cStr[1] ;
-			} else {
-				cString2[((x-1)*2)+1] = ' ' ;
-			}
+			bVal = cString[x-1] ;
+			cString2[(x-1)*2] = cHexChars[bVal >> 4] ;
+			cString2[((x-1)*2)+1] = cHexChars[bVal & 0x0F] ;
 		}
 		RING_API_RETSTRING2(cString2,nMax*2);
 		ring_state_free(((VM *) pPointer)->pRingState,cString2);


### PR DESCRIPTION
`str2hex` was using an `sprintf` call for each byte which is expensive. It's replaced by a simple and faster lookup-table algorithm which gives a factor 10 speedup.
Output of `str2hex` replaces the most significant nibble of a byte by a space if it is equal to zero: this makes the output confusing and not in conformance with standard hexadecimal representation as implemented by all major libraries and languages. It is also not coherent with builtin `hex()` function output.
For example, the byte array `{0x0A, 0xBC, 0x0D, 0x0E}` with be represented by "` abc d e`" which is naturally confusing to human eye (especially if " are not used). The usual representation for this byte array is "`0abc0d0e`"

The new output format is still compatible with hex2str function.