### PR TITLE
Speedup of hex2str implementation (10x) and better error code if input has odd number of chars

### DIFF
--- a/language/include/ring_api.h
+++ b/language/include/ring_api.h
@@ -132,6 +132,8 @@ void ring_vmlib_string ( void *pPointer ) ;
 
 void ring_vmlib_str2hex ( void *pPointer ) ;
 
+unsigned char ring_vmlib_hex2str_hex2nibble (char cVal) ;
+
 void ring_vmlib_hex2str ( void *pPointer ) ;
 
 void ring_vmlib_str2list ( void *pPointer ) ;
@@ -297,6 +299,8 @@ void ring_vmlib_addsublistsbyfastcopy ( void *pPointer ) ;
 #define RING_API_BADPARATYPE "Bad parameter type!"
 #define RING_API_BADPARACOUNT "Bad parameters count!"
 #define RING_API_BADPARARANGE "Bad parameters value, error in range!"
+#define RING_API_BADPARALENGTH "Bad parameters value, error in length!"
+#define RING_API_BADPARAVALUE "Bad parameter value!"
 #define RING_API_NOTPOINTER "Error in parameter, not pointer!"
 #define RING_API_NULLPOINTER "Error in parameter, NULL pointer!"
 #define RING_API_EMPTYLIST "Bad parameter, empty list!"


### PR DESCRIPTION
`hex2str` implementation was using `scanf` to convert from hexadecimal format which very slow. The new code uses simple hexadecimal conversion logic which is 10x faster.
`hex2str` implementation was expecting an even number of characters to process but didn't check for it. For example, if `nMax` is 1, the code will read past the end of the string at index 1. Luckily, the extra byte is zero and so a `scanf` error is displayed but it is better to check `nMax` from the beginning and report more adequate error.