### PR TITLE
Fix inconsistency of hex() function between Linux-64bit, Linux-32bit and  Windows-64bit

### DIFF
--- a/language/src/ring_api.c
+++ b/language/src/ring_api.c
@@ -1221,15 +1221,16 @@ void ring_vmlib_hex ( void *pPointer )
 
 void ring_vmlib_dec ( void *pPointer )
 {
-	unsigned long x  ;
+	unsigned long long x  ;
 	int nOutput  ;
 	if ( RING_API_PARACOUNT != 1 ) {
 		RING_API_ERROR(RING_API_MISS1PARA);
 		return ;
 	}
 	if ( RING_API_ISSTRING(1) ) {
-		nOutput = sscanf(RING_API_GETSTRING(1),"%lx",&x);
-		if ( nOutput == EOF ) {
+		nOutput = sscanf(RING_API_GETSTRING(1),"%llx",&x);
+		/* error if nOutput is zero which means that sscanf failed to convert any character */
+		if ( nOutput == EOF || nOutput == 0 ) {
 			RING_API_ERROR(RING_SSCANFERROR);
 			return ;
 		}

--- a/language/src/ring_api.c
+++ b/language/src/ring_api.c
@@ -1212,7 +1212,7 @@ void ring_vmlib_hex ( void *pPointer )
 		return ;
 	}
 	if ( RING_API_ISNUMBER(1) ) {
-		sprintf( cStr , "%lx" , (unsigned long) RING_API_GETNUMBER(1) ) ;
+		sprintf( cStr , "%llx" , (unsigned long long) RING_API_GETNUMBER(1) ) ;
 		RING_API_RETSTRING(cStr);
 	} else {
 		RING_API_ERROR(RING_API_BADPARATYPE);


### PR DESCRIPTION
`hex()` was returning different outputs for the same integer value on different platforms.
For example, output of `hex(999999999999999)` is "`38d7ea4c67fff`" on Linux-64bit but it is "`a4c67fff`" on Linux-32bit and Windows-64bit.
The issue was caused by the use of (`unsigned long`) type which has different size depending on the build platform.
The solution is to use (`unsigned long long`) which is guaranteed to be 64-bit on all platforms.