### PR TITLE
Fix Number() inconsistency with String(), add better error handling, make String() better handle integers

### DIFF
--- a/language/include/ring_vm.h
+++ b/language/include/ring_vm.h
@@ -762,6 +762,8 @@ List * ring_vm_getglobalscope ( VM *pVM ) ;
 #define RING_VM_ERROR_BADCOMMAND "Error (R37) : Sorry, The command is not supported in this context"
 #define RING_VM_ERROR_LIBLOADERROR "Error (R38) : Runtime Error in loading the dynamic library!"
 #define RING_VM_ERROR_TEMPFILENAME "Error (R39) : Error occurred creating unique filename."
+#define RING_VM_ERROR_NUMERICUNDERFLOW "Error (R40) : Numeric Underflow! "
+#define RING_VM_ERROR_NUMERICINVALID "Error (R41) : Invalid Numeric string "
 /* Extra Size (for eval) */
 #define RING_VM_EXTRASIZE 2
 #define RING_VM_MINVMINSTRUCTIONS 100000

--- a/language/src/ring_vmexpr.c
+++ b/language/src/ring_vmexpr.c
@@ -968,8 +968,18 @@ char * ring_vm_numtostring ( VM *pVM,double nNum1,char *cStr )
 {
 	char cOptions[10]  ;
 	int nNum2  ;
-	if ( nNum1 == (long long) nNum1 ) {
-		sprintf( cStr , "%lld" , (long long) nNum1 ) ;
+	long long nVal = (long long) nNum1;
+	/*
+	** https://en.wikipedia.org/wiki/IEEE_754
+	**
+	**  double type has 53 significant bits (52 bits of mantissa plus 1 implied)
+	**  so the maximum absolut integer value that can be stored in it without 
+	**  issue is (2^53 - 1) which is equal to 9007199254740991
+	**  So if the (long long) cast results in equality , we also check that the 
+	**  absolut value is less than or equal to 9007199254740991
+	*/
+	if ( (nNum1 == nVal) && (nVal >= -9007199254740991LL && nVal <= 9007199254740991LL) ) {
+		sprintf( cStr , "%lld" , nVal ) ;
 	}
 	else {
 		sprintf( cOptions , "%s%df" , "%.",pVM->nDecimals ) ;


### PR DESCRIPTION
`Number()` was not accepting strings created by `String()` if they are more than 15 characters. This made it impossible to load results from previous calculations. Moreover, `Number()` was not handling error cases correctly because of its use of `atof`.
The solution is to remove length limitation and to use `strtod` function which provides better error handling.

`String()` was printing decimal point even for exact integer values. This change makes it better handle exact integer values up to 53 bits in size ( `-9007199254740991` <= |value| <= `9007199254740991`)

Test program:

```
c1 = 999999999999999
for i = 1 to 13 {
	c1 *= 999999999999999
}

s = string(c1)
? "c1 = " + s
c2 = number(s)
? "c2 = " + c2

? "c2 - c1 = " + (c2 - c1)

str1 = "-2222044646462"
c = Number(str1)
str2 = String (c)

if str1 = str2 {
	? "Strings identical"

else
	? "Strings mismatch!!"
}
```