### PR TITLE
Fix memory leak in OpenSSL extension randbytes() and better handling of errors

### DIFF
--- a/extensions/ringopenssl/ring_vmopenssl.c
+++ b/extensions/ringopenssl/ring_vmopenssl.c
@@ -180,12 +180,17 @@ void ring_vm_openssl_randbytes ( void *pPointer )
 	if ( RING_API_ISNUMBER(1) ) {
 		nNum1 = (int) RING_API_GETNUMBER(1) ;
 		if ( nNum1 > 0 ) {
-			cStr =  malloc(nNum1+1) ;
-			if ( RAND_bytes(cStr,nNum1) ) {
-				RING_API_RETSTRING2((const char *) cStr,nNum1);
-			}
-			else {
-				RING_API_RETNUMBER(0);
+			cStr =  malloc(nNum1) ;
+			if (cStr) {
+				if ( RAND_bytes(cStr,nNum1) ) {
+					RING_API_RETSTRING2((const char *) cStr,nNum1);
+				}
+				else {
+					RING_API_ERROR(RING_API_INTERNALFAILURE);
+				}
+				free (cStr) ;
+			} else {
+				RING_API_ERROR(RING_OOM);
 			}
 		} else {
 			RING_API_ERROR(RING_API_BADPARATYPE);

--- a/language/include/ring_api.h
+++ b/language/include/ring_api.h
@@ -302,6 +302,7 @@ void ring_vmlib_addsublistsbyfastcopy ( void *pPointer ) ;
 #define RING_API_NOTPOINTER "Error in parameter, not pointer!"
 #define RING_API_NULLPOINTER "Error in parameter, NULL pointer!"
 #define RING_API_EMPTYLIST "Bad parameter, empty list!"
+#define RING_API_INTERNALFAILURE "Internal function call failed!"
 #define ring_vm_funcregister(x,y) ring_vm_funcregister2(pRingState,x,y)
 /*
 **  Note : The C Function Get Lists as pointers because of (List Pass by Reference) 


### PR DESCRIPTION
in `ring_vm_openssl_randbytes`, the pointer `cStr` was never freed. It was also allocated with an extra byte without reason and there was no check if `malloc` failed or not.

Finally, if the call to OpenSSL `RAND_bytes` failed, `ring_vm_openssl_randbytes()` was returning an an integer equal to 0 but it should fail instead