### PR TITLE
Fix memory leak re-introduced by commit 4b8f07fc9c1f7e2537101dd4f68593a01e964ebf "Update Visual Source (using PWCT)"

### DIFF
--- a/extensions/ringopenssl/ring_vmopenssl.c
+++ b/extensions/ringopenssl/ring_vmopenssl.c
@@ -191,6 +191,7 @@ void ring_vm_openssl_randbytes ( void *pPointer )
 			else {
 				RING_API_ERROR(RING_API_INTERNALFAILURE);
 			}
+			free (cStr) ;
 		} else {
 			RING_API_ERROR(RING_API_BADPARATYPE);
 		}


### PR DESCRIPTION
Unfortunately, during code refactoring of `ring_vm_openssl_randbytes`, the "`free`" statement was lost