### PR TITLE
Implement multi-part hash functions in OpenSSL extension (XXXinit, XXXupdate, XXXfinal)

### DIFF
--- a/extensions/ringopenssl/ring_vmopenssl.c
+++ b/extensions/ringopenssl/ring_vmopenssl.c
@@ -20,22 +20,119 @@
 
 RING_API void ringlib_init ( RingState *pRingState )
 {
+	ring_vm_funcregister("md5init",ring_vm_openssl_md5_init);
+	ring_vm_funcregister("md5update",ring_vm_openssl_md5_update);
+	ring_vm_funcregister("md5final",ring_vm_openssl_md5_final);
 	ring_vm_funcregister("md5",ring_vm_openssl_md5);
+	ring_vm_funcregister("sha1init",ring_vm_openssl_sha1_init);
+	ring_vm_funcregister("sha1update",ring_vm_openssl_sha1_update);
+	ring_vm_funcregister("sha1final",ring_vm_openssl_sha1_final);
 	ring_vm_funcregister("sha1",ring_vm_openssl_sha1);
+	ring_vm_funcregister("sha256init",ring_vm_openssl_sha256_init);
+	ring_vm_funcregister("sha256update",ring_vm_openssl_sha256_update);
+	ring_vm_funcregister("sha256final",ring_vm_openssl_sha256_final);
 	ring_vm_funcregister("sha256",ring_vm_openssl_sha256);
+	ring_vm_funcregister("sha512init",ring_vm_openssl_sha512_init);
+	ring_vm_funcregister("sha512update",ring_vm_openssl_sha512_update);
+	ring_vm_funcregister("sha512final",ring_vm_openssl_sha512_final);
 	ring_vm_funcregister("sha512",ring_vm_openssl_sha512);
+	ring_vm_funcregister("sha384init",ring_vm_openssl_sha384_init);
+	ring_vm_funcregister("sha384update",ring_vm_openssl_sha384_update);
+	ring_vm_funcregister("sha384final",ring_vm_openssl_sha384_final);
 	ring_vm_funcregister("sha384",ring_vm_openssl_sha384);
+	ring_vm_funcregister("sha224init",ring_vm_openssl_sha224_init);
+	ring_vm_funcregister("sha224update",ring_vm_openssl_sha224_update);
+	ring_vm_funcregister("sha224final",ring_vm_openssl_sha224_final);
 	ring_vm_funcregister("sha224",ring_vm_openssl_sha224);
 	ring_vm_funcregister("encrypt",ring_vm_openssl_encrypt);
 	ring_vm_funcregister("decrypt",ring_vm_openssl_decrypt);
 	ring_vm_funcregister("randbytes",ring_vm_openssl_randbytes);
 }
 
+static void ring_vm_openssl_buf2hex (const unsigned char* pData, int nLen, char* cStr)
+{
+	static const char cHexChars[] = "0123456789abcdef" ;
+	unsigned char bVal ;
+	int i ;
+	for (i = 0; i < nLen; i++) {
+		bVal = pData[i];
+		cStr[i*2] = cHexChars[bVal >> 4] ;
+		cStr[(i*2)+1] = cHexChars[bVal & 0x0F] ;
+	}
+	cStr[2*nLen] = 0;
+}
+
+void ring_vm_openssl_md5_init ( void *pPointer )
+{
+	if ( RING_API_PARACOUNT != 0 ) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	else {
+		MD5_CTX* pValue ;
+		pValue = (MD5_CTX *) ring_state_malloc(((VM *) pPointer)->pRingState,sizeof(MD5_CTX)) ;
+		MD5_Init (pValue);
+		RING_API_RETMANAGEDCPOINTER(pValue,"MD5_CTX",ring_state_free);
+	}
+}
+
+void ring_vm_openssl_md5_update ( void *pPointer )
+{
+	int x,nSize  ;
+	char *cInput  ;
+	MD5_CTX* pValue ;
+	if ( RING_API_PARACOUNT != 2 ) {
+		RING_API_ERROR(RING_API_MISS1PARA);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	if ( ! RING_API_ISSTRING(2) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	pValue = (MD5_CTX *) RING_API_GETCPOINTER(1,"MD5_CTX") ;
+	if ( pValue == NULL) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	cInput = RING_API_GETSTRING(2) ;
+	nSize = RING_API_GETSTRINGSIZE(2) ;
+	RING_API_RETNUMBER(MD5_Update(pValue, cInput, (unsigned long) nSize));
+}
+
+void ring_vm_openssl_md5_final ( void *pPointer )
+{
+	unsigned char digest[MD5_DIGEST_LENGTH]  ;
+	char cString[MD5_DIGEST_LENGTH*2+1]  ;
+	int nSize  ;
+	char *cInput  ;
+	MD5_CTX* pValue ;
+	if ( RING_API_PARACOUNT != 1 ) {
+		RING_API_ERROR(RING_API_MISS1PARA);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return;
+	}
+	pValue = (MD5_CTX *) RING_API_GETCPOINTER(1,"MD5_CTX") ;
+	if ( pValue == NULL) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	MD5_Final (digest, pValue);
+	ring_vm_openssl_buf2hex (digest, MD5_DIGEST_LENGTH, cString);
+	RING_API_RETSTRING(cString);
+}
+
 void ring_vm_openssl_md5 ( void *pPointer )
 {
 	unsigned char digest[MD5_DIGEST_LENGTH]  ;
 	char cString[33]  ;
-	int x,nSize  ;
+	int nSize  ;
 	char *cInput  ;
 	if ( RING_API_PARACOUNT != 1 ) {
 		RING_API_ERROR(RING_API_MISS1PARA);
@@ -45,20 +142,83 @@ void ring_vm_openssl_md5 ( void *pPointer )
 		cInput = RING_API_GETSTRING(1) ;
 		nSize = RING_API_GETSTRINGSIZE(1) ;
 		MD5((unsigned char *) cInput, nSize, (unsigned char *) &digest);
-		for ( x = 0 ; x < 16 ; x++ ) {
-			sprintf( &cString[x*2] , "%02x" , (unsigned int) digest[x] ) ;
-		}
+		ring_vm_openssl_buf2hex (digest, MD5_DIGEST_LENGTH, cString);
 		RING_API_RETSTRING(cString);
 	} else {
 		RING_API_ERROR(RING_API_BADPARATYPE);
 	}
 }
 
+void ring_vm_openssl_sha1_init ( void *pPointer )
+{
+	if ( RING_API_PARACOUNT != 0 ) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	else {
+		SHA_CTX* pValue ;
+		pValue = (SHA_CTX *) ring_state_malloc(((VM *) pPointer)->pRingState,sizeof(SHA_CTX)) ;
+		SHA1_Init (pValue);
+		RING_API_RETMANAGEDCPOINTER(pValue,"SHA_CTX",ring_state_free);
+	}
+}
+
+void ring_vm_openssl_sha1_update ( void *pPointer )
+{
+	int x,nSize  ;
+	char *cInput  ;
+	SHA_CTX* pValue ;
+	if ( RING_API_PARACOUNT != 2 ) {
+		RING_API_ERROR(RING_API_MISS1PARA);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	if ( ! RING_API_ISSTRING(2) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	pValue = (SHA_CTX *) RING_API_GETCPOINTER(1,"SHA_CTX") ;
+	if ( pValue == NULL ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	cInput = RING_API_GETSTRING(2) ;
+	nSize = RING_API_GETSTRINGSIZE(2) ;
+	RING_API_RETNUMBER(SHA1_Update(pValue, cInput, (unsigned long) nSize));
+}
+
+void ring_vm_openssl_sha1_final ( void *pPointer )
+{
+	unsigned char digest[SHA_DIGEST_LENGTH]  ;
+	char cString[SHA_DIGEST_LENGTH*2+1]  ;
+	int nSize  ;
+	char *cInput  ;
+	SHA_CTX* pValue ;
+	if ( RING_API_PARACOUNT != 1 ) {
+		RING_API_ERROR(RING_API_MISS1PARA);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+	}
+	pValue = (SHA_CTX *) RING_API_GETCPOINTER(1,"SHA_CTX") ;
+	if ( pValue == NULL ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	SHA1_Final (digest, pValue);
+	ring_vm_openssl_buf2hex (digest, SHA_DIGEST_LENGTH, cString);
+	RING_API_RETSTRING(cString);
+}
+
 void ring_vm_openssl_sha1 ( void *pPointer )
 {
 	unsigned char digest[SHA_DIGEST_LENGTH]  ;
 	char cString[SHA_DIGEST_LENGTH*2+1]  ;
-	int x,nSize  ;
+	int nSize  ;
 	char *cInput  ;
 	if ( RING_API_PARACOUNT != 1 ) {
 		RING_API_ERROR(RING_API_MISS1PARA);
@@ -68,20 +228,84 @@ void ring_vm_openssl_sha1 ( void *pPointer )
 		cInput = RING_API_GETSTRING(1) ;
 		nSize = RING_API_GETSTRINGSIZE(1) ;
 		SHA1((unsigned char *) cInput, nSize, (unsigned char *) &digest);
-		for ( x = 0 ; x < SHA_DIGEST_LENGTH ; x++ ) {
-			sprintf( &cString[x*2] , "%02x" , (unsigned int) digest[x] ) ;
-		}
+		ring_vm_openssl_buf2hex (digest, SHA_DIGEST_LENGTH, cString);
 		RING_API_RETSTRING(cString);
 	} else {
 		RING_API_ERROR(RING_API_BADPARATYPE);
 	}
 }
 
+void ring_vm_openssl_sha256_init ( void *pPointer )
+{
+	if ( RING_API_PARACOUNT != 0 ) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	else {
+		SHA256_CTX* pValue;
+		pValue = (SHA256_CTX *) ring_state_malloc(((VM *) pPointer)->pRingState,sizeof(SHA256_CTX)) ;
+		SHA256_Init (pValue);
+		RING_API_RETMANAGEDCPOINTER(pValue,"SHA256_CTX",ring_state_free);
+	}
+}
+
+void ring_vm_openssl_sha256_update ( void *pPointer )
+{
+	int x,nSize  ;
+	char *cInput  ;
+	SHA256_CTX* pValue ;
+	if ( RING_API_PARACOUNT != 2 ) {
+		RING_API_ERROR(RING_API_MISS1PARA);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	if ( ! RING_API_ISSTRING(2) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	pValue = (SHA256_CTX *) RING_API_GETCPOINTER(1,"SHA256_CTX");
+	if ( ! pValue ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	cInput = RING_API_GETSTRING(2) ;
+	nSize = RING_API_GETSTRINGSIZE(2) ;
+	RING_API_RETNUMBER(SHA256_Update(pValue, cInput, (unsigned long) nSize));
+}
+
+void ring_vm_openssl_sha256_final ( void *pPointer )
+{
+	unsigned char digest[SHA256_DIGEST_LENGTH]  ;
+	char cString[SHA256_DIGEST_LENGTH*2+1]  ;
+	int nSize  ;
+	char *cInput  ;
+	SHA256_CTX* pValue ;
+	if ( RING_API_PARACOUNT != 1 ) {
+		RING_API_ERROR(RING_API_MISS1PARA);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	pValue = (SHA256_CTX *) RING_API_GETCPOINTER(1,"SHA256_CTX") ;
+	if ( ! pValue ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	SHA256_Final (digest, pValue);
+	ring_vm_openssl_buf2hex (digest, SHA256_DIGEST_LENGTH, cString);
+	RING_API_RETSTRING(cString);
+}
+
 void ring_vm_openssl_sha256 ( void *pPointer )
 {
 	unsigned char digest[SHA256_DIGEST_LENGTH]  ;
 	char cString[SHA256_DIGEST_LENGTH*2+1]  ;
-	int x,nSize  ;
+	int nSize  ;
 	char *cInput  ;
 	if ( RING_API_PARACOUNT != 1 ) {
 		RING_API_ERROR(RING_API_MISS1PARA);
@@ -91,20 +315,83 @@ void ring_vm_openssl_sha256 ( void *pPointer )
 		cInput = RING_API_GETSTRING(1) ;
 		nSize = RING_API_GETSTRINGSIZE(1) ;
 		SHA256((unsigned char *) cInput, nSize, (unsigned char *) &digest);
-		for ( x = 0 ; x < SHA256_DIGEST_LENGTH ; x++ ) {
-			sprintf( &cString[x*2] , "%02x" , (unsigned int) digest[x] ) ;
-		}
+		ring_vm_openssl_buf2hex (digest, SHA256_DIGEST_LENGTH, cString);
 		RING_API_RETSTRING(cString);
 	} else {
 		RING_API_ERROR(RING_API_BADPARATYPE);
 	}
 }
 
+void ring_vm_openssl_sha512_init ( void *pPointer )
+{
+	if ( RING_API_PARACOUNT != 0 ) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	else {
+		SHA512_CTX* pValue;
+		pValue = (SHA512_CTX *) ring_state_malloc(((VM *) pPointer)->pRingState,sizeof(SHA512_CTX)) ;
+		SHA512_Init (pValue);
+		RING_API_RETMANAGEDCPOINTER(pValue,"SHA512_CTX",ring_state_free);
+	}
+}
+
+void ring_vm_openssl_sha512_update ( void *pPointer )
+{
+	int x,nSize  ;
+	char *cInput  ;
+	SHA512_CTX* pValue ;
+	if ( RING_API_PARACOUNT != 2 ) {
+		RING_API_ERROR(RING_API_MISS1PARA);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	if ( ! RING_API_ISSTRING(2) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	pValue = (SHA512_CTX *) RING_API_GETCPOINTER(1,"SHA512_CTX") ;
+	if ( ! pValue ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	cInput = RING_API_GETSTRING(2) ;
+	nSize = RING_API_GETSTRINGSIZE(2) ;
+	RING_API_RETNUMBER(SHA512_Update(pValue, cInput, (unsigned long) nSize));
+}
+
+void ring_vm_openssl_sha512_final ( void *pPointer )
+{
+	unsigned char digest[SHA512_DIGEST_LENGTH]  ;
+	char cString[SHA512_DIGEST_LENGTH*2+1]  ;
+	int nSize  ;
+	char *cInput  ;
+	SHA512_CTX* pValue ;
+	if ( RING_API_PARACOUNT != 1 ) {
+		RING_API_ERROR(RING_API_MISS1PARA);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+	}
+	pValue = (SHA512_CTX *) RING_API_GETCPOINTER(1,"SHA512_CTX") ;
+	if ( ! pValue ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	SHA512_Final (digest, pValue);
+	ring_vm_openssl_buf2hex (digest, SHA512_DIGEST_LENGTH, cString);
+	RING_API_RETSTRING(cString);
+}
+
 void ring_vm_openssl_sha512 ( void *pPointer )
 {
 	unsigned char digest[SHA512_DIGEST_LENGTH]  ;
 	char cString[SHA512_DIGEST_LENGTH*2+1]  ;
-	int x,nSize  ;
+	int nSize  ;
 	char *cInput  ;
 	if ( RING_API_PARACOUNT != 1 ) {
 		RING_API_ERROR(RING_API_MISS1PARA);
@@ -114,20 +401,83 @@ void ring_vm_openssl_sha512 ( void *pPointer )
 		cInput = RING_API_GETSTRING(1) ;
 		nSize = RING_API_GETSTRINGSIZE(1) ;
 		SHA512((unsigned char *) cInput, nSize, (unsigned char *) &digest);
-		for ( x = 0 ; x < SHA512_DIGEST_LENGTH ; x++ ) {
-			sprintf( &cString[x*2] , "%02x" , (unsigned int) digest[x] ) ;
-		}
+		ring_vm_openssl_buf2hex (digest, SHA512_DIGEST_LENGTH, cString);
 		RING_API_RETSTRING(cString);
 	} else {
 		RING_API_ERROR(RING_API_BADPARATYPE);
 	}
 }
 
+void ring_vm_openssl_sha384_init ( void *pPointer )
+{
+	if ( RING_API_PARACOUNT != 0 ) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	else {
+		SHA512_CTX* pValue;
+		pValue = (SHA512_CTX *) ring_state_malloc(((VM *) pPointer)->pRingState,sizeof(SHA512_CTX)) ;
+		SHA384_Init (pValue);
+		RING_API_RETMANAGEDCPOINTER(pValue,"SHA512_384_CTX",ring_state_free);
+	}
+}
+
+void ring_vm_openssl_sha384_update ( void *pPointer )
+{
+	int x,nSize  ;
+	char *cInput  ;
+	SHA512_CTX* pValue ;
+	if ( RING_API_PARACOUNT != 2 ) {
+		RING_API_ERROR(RING_API_MISS1PARA);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	if ( ! RING_API_ISSTRING(2) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	pValue = (SHA512_CTX *) RING_API_GETCPOINTER(1,"SHA512_384_CTX") ;
+	if ( ! pValue ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	cInput = RING_API_GETSTRING(2) ;
+	nSize = RING_API_GETSTRINGSIZE(2) ;
+	RING_API_RETNUMBER(SHA384_Update(pValue, cInput, (unsigned long) nSize));
+}
+
+void ring_vm_openssl_sha384_final ( void *pPointer )
+{
+	unsigned char digest[SHA384_DIGEST_LENGTH]  ;
+	char cString[SHA384_DIGEST_LENGTH*2+1]  ;
+	int nSize  ;
+	char *cInput  ;
+	SHA512_CTX* pValue ;
+	if ( RING_API_PARACOUNT != 1 ) {
+		RING_API_ERROR(RING_API_MISS1PARA);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+	}
+	pValue = (SHA512_CTX *) RING_API_GETCPOINTER(1,"SHA512_384_CTX") ;
+	if ( ! pValue ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	SHA384_Final (digest, pValue);
+	ring_vm_openssl_buf2hex (digest, SHA384_DIGEST_LENGTH, cString);
+	RING_API_RETSTRING(cString);
+}
+
 void ring_vm_openssl_sha384 ( void *pPointer )
 {
 	unsigned char digest[SHA384_DIGEST_LENGTH]  ;
 	char cString[SHA384_DIGEST_LENGTH*2+1]  ;
-	int x,nSize  ;
+	int nSize  ;
 	char *cInput  ;
 	if ( RING_API_PARACOUNT != 1 ) {
 		RING_API_ERROR(RING_API_MISS1PARA);
@@ -137,20 +487,83 @@ void ring_vm_openssl_sha384 ( void *pPointer )
 		cInput = RING_API_GETSTRING(1) ;
 		nSize = RING_API_GETSTRINGSIZE(1) ;
 		SHA384((unsigned char *) cInput, nSize, (unsigned char *) &digest);
-		for ( x = 0 ; x < SHA384_DIGEST_LENGTH ; x++ ) {
-			sprintf( &cString[x*2] , "%02x" , (unsigned int) digest[x] ) ;
-		}
+		ring_vm_openssl_buf2hex (digest, SHA384_DIGEST_LENGTH, cString);
 		RING_API_RETSTRING(cString);
 	} else {
 		RING_API_ERROR(RING_API_BADPARATYPE);
 	}
 }
 
+void ring_vm_openssl_sha224_init ( void *pPointer )
+{
+	if ( RING_API_PARACOUNT != 0 ) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	else {
+		SHA256_CTX* pValue;
+		pValue = (SHA256_CTX *) ring_state_malloc(((VM *) pPointer)->pRingState,sizeof(SHA256_CTX)) ;
+		SHA224_Init (pValue);
+		RING_API_RETMANAGEDCPOINTER(pValue,"SHA256_224_CTX",ring_state_free);
+	}
+}
+
+void ring_vm_openssl_sha224_update ( void *pPointer )
+{
+	int x,nSize  ;
+	char *cInput  ;
+	SHA256_CTX* pValue ;
+	if ( RING_API_PARACOUNT != 2 ) {
+		RING_API_ERROR(RING_API_MISS1PARA);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	if ( ! RING_API_ISSTRING(2) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	pValue = (SHA256_CTX *) RING_API_GETCPOINTER(1,"SHA256_224_CTX") ;
+	if ( ! pValue ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	cInput = RING_API_GETSTRING(2) ;
+	nSize = RING_API_GETSTRINGSIZE(2) ;
+	RING_API_RETNUMBER(SHA224_Update(pValue, cInput, (unsigned long) nSize));
+}
+
+void ring_vm_openssl_sha224_final ( void *pPointer )
+{
+	unsigned char digest[SHA224_DIGEST_LENGTH]  ;
+	char cString[SHA224_DIGEST_LENGTH*2+1]  ;
+	int nSize  ;
+	char *cInput  ;
+	SHA256_CTX* pValue ;
+	if ( RING_API_PARACOUNT != 1 ) {
+		RING_API_ERROR(RING_API_MISS1PARA);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+	}
+	pValue = (SHA256_CTX *) RING_API_GETCPOINTER(1,"SHA256_224_CTX") ;
+	if ( ! pValue ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	SHA224_Final (digest, pValue);
+	ring_vm_openssl_buf2hex (digest, SHA224_DIGEST_LENGTH, cString);
+	RING_API_RETSTRING(cString);
+}
+
 void ring_vm_openssl_sha224 ( void *pPointer )
 {
 	unsigned char digest[SHA224_DIGEST_LENGTH]  ;
 	char cString[SHA224_DIGEST_LENGTH*2+1]  ;
-	int x,nSize  ;
+	int nSize  ;
 	char *cInput  ;
 	if ( RING_API_PARACOUNT != 1 ) {
 		RING_API_ERROR(RING_API_MISS1PARA);
@@ -160,9 +573,7 @@ void ring_vm_openssl_sha224 ( void *pPointer )
 		cInput = RING_API_GETSTRING(1) ;
 		nSize = RING_API_GETSTRINGSIZE(1) ;
 		SHA224((unsigned char *) cInput, nSize, (unsigned char *) &digest);
-		for ( x = 0 ; x < SHA224_DIGEST_LENGTH ; x++ ) {
-			sprintf( &cString[x*2] , "%02x" , (unsigned int) digest[x] ) ;
-		}
+		ring_vm_openssl_buf2hex (digest, SHA224_DIGEST_LENGTH, cString);
 		RING_API_RETSTRING(cString);
 	} else {
 		RING_API_ERROR(RING_API_BADPARATYPE);

--- a/extensions/ringopenssl/ring_vmopenssl.c
+++ b/extensions/ringopenssl/ring_vmopenssl.c
@@ -418,7 +418,7 @@ void ring_vm_openssl_sha384_init ( void *pPointer )
 		SHA512_CTX* pValue;
 		pValue = (SHA512_CTX *) ring_state_malloc(((VM *) pPointer)->pRingState,sizeof(SHA512_CTX)) ;
 		SHA384_Init (pValue);
-		RING_API_RETMANAGEDCPOINTER(pValue,"SHA512_384_CTX",ring_state_free);
+		RING_API_RETMANAGEDCPOINTER(pValue,"SHA384_CTX",ring_state_free);
 	}
 }
 
@@ -439,7 +439,7 @@ void ring_vm_openssl_sha384_update ( void *pPointer )
 		RING_API_ERROR(RING_API_BADPARATYPE);
 		return ;
 	}
-	pValue = (SHA512_CTX *) RING_API_GETCPOINTER(1,"SHA512_384_CTX") ;
+	pValue = (SHA512_CTX *) RING_API_GETCPOINTER(1,"SHA384_CTX") ;
 	if ( ! pValue ) {
 		RING_API_ERROR(RING_API_BADPARATYPE);
 		return ;
@@ -463,7 +463,7 @@ void ring_vm_openssl_sha384_final ( void *pPointer )
 	if ( ! RING_API_ISCPOINTER(1) ) {
 		RING_API_ERROR(RING_API_BADPARATYPE);
 	}
-	pValue = (SHA512_CTX *) RING_API_GETCPOINTER(1,"SHA512_384_CTX") ;
+	pValue = (SHA512_CTX *) RING_API_GETCPOINTER(1,"SHA384_CTX") ;
 	if ( ! pValue ) {
 		RING_API_ERROR(RING_API_BADPARATYPE);
 		return ;
@@ -504,7 +504,7 @@ void ring_vm_openssl_sha224_init ( void *pPointer )
 		SHA256_CTX* pValue;
 		pValue = (SHA256_CTX *) ring_state_malloc(((VM *) pPointer)->pRingState,sizeof(SHA256_CTX)) ;
 		SHA224_Init (pValue);
-		RING_API_RETMANAGEDCPOINTER(pValue,"SHA256_224_CTX",ring_state_free);
+		RING_API_RETMANAGEDCPOINTER(pValue,"SHA224_CTX",ring_state_free);
 	}
 }
 
@@ -525,7 +525,7 @@ void ring_vm_openssl_sha224_update ( void *pPointer )
 		RING_API_ERROR(RING_API_BADPARATYPE);
 		return ;
 	}
-	pValue = (SHA256_CTX *) RING_API_GETCPOINTER(1,"SHA256_224_CTX") ;
+	pValue = (SHA256_CTX *) RING_API_GETCPOINTER(1,"SHA224_CTX") ;
 	if ( ! pValue ) {
 		RING_API_ERROR(RING_API_BADPARATYPE);
 		return ;
@@ -549,7 +549,7 @@ void ring_vm_openssl_sha224_final ( void *pPointer )
 	if ( ! RING_API_ISCPOINTER(1) ) {
 		RING_API_ERROR(RING_API_BADPARATYPE);
 	}
-	pValue = (SHA256_CTX *) RING_API_GETCPOINTER(1,"SHA256_224_CTX") ;
+	pValue = (SHA256_CTX *) RING_API_GETCPOINTER(1,"SHA224_CTX") ;
 	if ( ! pValue ) {
 		RING_API_ERROR(RING_API_BADPARATYPE);
 		return ;

--- a/extensions/ringopenssl/ring_vmopenssl.h
+++ b/extensions/ringopenssl/ring_vmopenssl.h
@@ -5,15 +5,51 @@
 
 RING_API void ringlib_init ( RingState *pRingState ) ;
 
+void ring_vm_openssl_md5_init ( void *pPointer ) ;
+
+void ring_vm_openssl_md5_update ( void *pPointer ) ;
+
+void ring_vm_openssl_md5_final ( void *pPointer ) ;
+
 void ring_vm_openssl_md5 ( void *pPointer ) ;
+
+void ring_vm_openssl_sha1_init ( void *pPointer ) ;
+
+void ring_vm_openssl_sha1_update ( void *pPointer ) ;
+
+void ring_vm_openssl_sha1_final ( void *pPointer ) ;
 
 void ring_vm_openssl_sha1 ( void *pPointer ) ;
 
+void ring_vm_openssl_sha256_init ( void *pPointer ) ;
+
+void ring_vm_openssl_sha256_update ( void *pPointer ) ;
+
+void ring_vm_openssl_sha256_final ( void *pPointer ) ;
+
 void ring_vm_openssl_sha256 ( void *pPointer ) ;
+
+void ring_vm_openssl_sha512_init ( void *pPointer ) ;
+
+void ring_vm_openssl_sha512_update ( void *pPointer ) ;
+
+void ring_vm_openssl_sha512_final ( void *pPointer ) ;
 
 void ring_vm_openssl_sha512 ( void *pPointer ) ;
 
+void ring_vm_openssl_sha384_init ( void *pPointer ) ;
+
+void ring_vm_openssl_sha384_update ( void *pPointer ) ;
+
+void ring_vm_openssl_sha384_final ( void *pPointer ) ;
+
 void ring_vm_openssl_sha384 ( void *pPointer ) ;
+
+void ring_vm_openssl_sha224_init ( void *pPointer ) ;
+
+void ring_vm_openssl_sha224_update ( void *pPointer ) ;
+
+void ring_vm_openssl_sha224_final ( void *pPointer ) ;
 
 void ring_vm_openssl_sha224 ( void *pPointer ) ;
 

--- a/extensions/ringopenssl/test_hash.ring
+++ b/extensions/ringopenssl/test_hash.ring
@@ -1,0 +1,75 @@
+load "openssllib.ring"
+
+// MD5
+a = md5Init()
+
+md5Update (a, "The quick brown fox ") and md5Update (a, "jumps over ") and md5Update (a, "the lazy dog")
+
+digest_a = md5Final(a)
+digest_b = md5("The quick brown fox jumps over the lazy dog")
+
+digest = "9e107d9d372bb6826bd81d3542a419d6"
+
+checkResults("MD5", digest_a, digest_b, digest)
+
+// SHA1
+a = sha1Init()
+sha1Update (a, "The quick brown fox ") and sha1Update (a, "jumps over ") and sha1Update (a, "the lazy dog")
+
+digest_a = sha1Final(a)
+digest_b = sha1("The quick brown fox jumps over the lazy dog")
+digest = "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+
+checkResults("SHA1", digest_a, digest_b, digest)
+
+// SHA224
+a = sha224Init()
+sha224Update (a, "The quick brown fox ") and sha224Update (a, "jumps over ") and sha224Update (a, "the lazy dog")
+
+digest_a = sha224Final(a)
+digest_b = sha224("The quick brown fox jumps over the lazy dog")
+digest = "730e109bd7a8a32b1cb9d9a09aa2325d2430587ddbc0c38bad911525"
+
+checkResults("SHA224", digest_a, digest_b, digest)
+
+// SHA256
+a = sha256Init()
+sha256Update (a, "The quick brown fox ") and sha256Update (a, "jumps over ") and sha256Update (a, "the lazy dog")
+
+digest_a = sha256Final(a)
+digest_b = sha256("The quick brown fox jumps over the lazy dog")
+digest = "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"
+
+checkResults("SHA256", digest_a, digest_b, digest)
+
+// SHA384
+a = sha384Init()
+sha384Update (a, "The quick brown fox ") and sha384Update (a, "jumps over ") and sha384Update (a, "the lazy dog")
+
+digest_a = sha384Final(a)
+digest_b = sha384("The quick brown fox jumps over the lazy dog")
+digest = "ca737f1014a48f4c0b6dd43cb177b0afd9e5169367544c494011e3317dbf9a509cb1e5dc1e85a941bbee3d7f2afbc9b1"
+
+checkResults("SHA384", digest_a, digest_b, digest)
+
+// SHA512
+a = sha512Init()
+sha512Update (a, "The quick brown fox ") and sha512Update (a, "jumps over ") and sha512Update (a, "the lazy dog")
+
+digest_a = sha512Final(a)
+digest_b = sha512("The quick brown fox jumps over the lazy dog")
+digest = "07e547d9586f6a73f73fbac0435ed76951218fb7d0c8d788a309d785436bbb642e93a252a954f23912547d1e8a3b5ed6e1bfd7097821233fa0538f3db854fee6"
+
+checkResults("SHA512", digest_a, digest_b, digest)
+
+func checkResults(name, dgstMulti, dgstSingle, dgstEspected) {
+	if dgstEspected != dgstMulti or dgstEspected != dgstSingle {
+		? name + " Test failed!"
+		? "    multi-part  = " + dgstMulti
+		? "    single-part = " + dgstSingle
+		? "    expected    = " + dgstEspected
+	else
+		? name + " Test OK"
+	}
+}
+


### PR DESCRIPTION
These news functions enable to compute hash of large files and large data without the need of loading all content in a single string variable
A test script is also add to validate the implementation of these functions and to show their typical usage.
The new functions are below. For each hash algorithm, a new type is define for the variable returned by the corresponding XXXinit function.

```
md5init() -> MD5_CTX
md5update (MD5_CTX, string) -> 1 for success or 0 for failure
md5final (MD5_CTX) -> string

sha1init() -> SHA_CTX
sha1update (SHA_CTX, string) -> 1 for success or 0 for failure
sha1final (SHA_CTX) -> string

sha224init() -> SHA224_CTX
sha224update (SHA224_CTX, string) -> 1 for success or 0 for failure
sha224final (SHA224_CTX) -> string

sha256init() -> SHA256_CTX
sha256update (SHA256_CTX, string) -> 1 for success or 0 for failure
sha256final (SHA256_CTX) -> string

sha384init() -> SHA384_CTX
sha384update (SHA384_CTX, string) -> 1 for success or 0 for failure
sha384final (SHA384_CTX) -> string

sha512init() -> SHA512_CTX
sha512update (SHA512_CTX, string) -> 1 for success or 0 for failure
sha512final (SHA512_CTX) -> string

```