### PR TITLE
Speedup string append (10x to 800x) by using realloc instead of malloc/free and fix ring_state_realloc implementation

### DIFF
--- a/language/include/ring_pooldata.h
+++ b/language/include/ring_pooldata.h
@@ -20,6 +20,7 @@ typedef struct PoolData {
 		HashItem vHashItem  ;
 		char cChar[RING_POOLMANAGER_ITEMSIZE]  ;
 	} PoolDataTypes ;
+	int nAllocatedSize;
 	struct PoolData *pNext  ;
 } PoolData ;
 typedef struct PoolManager {

--- a/language/include/ring_pooldata.h
+++ b/language/include/ring_pooldata.h
@@ -20,7 +20,6 @@ typedef struct PoolData {
 		HashItem vHashItem  ;
 		char cChar[RING_POOLMANAGER_ITEMSIZE]  ;
 	} PoolDataTypes ;
-	int nAllocatedSize;
 	struct PoolData *pNext  ;
 } PoolData ;
 typedef struct PoolManager {

--- a/language/include/ring_vmgc.h
+++ b/language/include/ring_vmgc.h
@@ -57,6 +57,8 @@ void ring_poolmanager_newblock ( RingState *pRingState ) ;
 
 void * ring_poolmanager_allocate ( RingState *pRingState,size_t size ) ;
 
+int ring_poolmanager_find ( RingState *pRingState,void *pMemory ) ;
+
 int ring_poolmanager_free ( RingState *pRingState,void *pMemory ) ;
 
 void ring_poolmanager_new ( RingState *pRingState ) ;

--- a/language/include/ring_vmgc.h
+++ b/language/include/ring_vmgc.h
@@ -42,7 +42,7 @@ RING_API void ring_state_free ( void *pState,void *pMemory ) ;
 
 RING_API void * ring_state_calloc ( void *pState,size_t nitems, size_t size ) ;
 
-RING_API void * ring_state_realloc ( void *pState,void *ptr, size_t size ) ;
+RING_API void * ring_state_realloc ( void *pState,void *ptr, size_t nAllocatedSize, size_t size ) ;
 
 void ring_vm_gc_deleteitem_gc ( void *pState,Item *pItem ) ;
 

--- a/language/src/ring_string.c
+++ b/language/src/ring_string.c
@@ -85,25 +85,26 @@ RING_API void ring_string_add2_gc ( void *pState,String *pString,const char *str
 {
 	int x  ;
 	int x2  ;
+	int nOriginalSize;
 	char *cStr  ;
 	assert(pString != NULL);
-	x2 = nStrSize+ring_string_size(pString) ;
-	cStr = pString->cStr ;
-	pString->cStr = (char *) ring_state_malloc(pState,x2+1);
+	nOriginalSize = ring_string_size(pString) ;
+	x2 = nStrSize+nOriginalSize ;
+	pString->cStr = (char *) ring_state_realloc(pState,pString->cStr,x2+1);
 	if ( pString->cStr  == NULL ) {
 		printf( RING_OOM ) ;
 		exit(0);
 	}
 	/* Copy String */
-	for ( x = 0 ; x < ring_string_size(pString) ; x++ ) {
-		pString->cStr[x] = cStr[x] ;
-	}
-	for ( x = 0 ; x < nStrSize ; x++ ) {
-		pString->cStr[x+ring_string_size(pString)] = str[x] ;
+	if (nStrSize < 64) {
+		for ( x = 0 ; x < nStrSize ; x++ ) {
+			pString->cStr[x+nOriginalSize] = str[x] ;
+		}
+	} else {
+		memcpy (pString->cStr + nOriginalSize, str, nStrSize);
 	}
 	pString->cStr[x2] = '\0' ;
 	pString->nSize = x2 ;
-	ring_state_free(pState,cStr);
 }
 
 RING_API void ring_string_print ( String *pString )

--- a/language/src/ring_string.c
+++ b/language/src/ring_string.c
@@ -24,8 +24,13 @@ RING_API String * ring_string_new2_gc ( void *pState,const char *str,int nStrSiz
 		exit(0);
 	}
 	/* Copy String */
-	for ( x = 0 ; x < nStrSize ; x++ ) {
-		pString->cStr[x] = str[x] ;
+	if (nStrSize < 64) {
+		/* benchmarks show that below 64 bytes, memcpy gain is not significant */
+		for ( x = 0 ; x < nStrSize ; x++ ) {
+			pString->cStr[x] = str[x] ;
+		}
+	} else {
+		memcpy (pString->cStr, str, nStrSize);
 	}
 	pString->cStr[nStrSize] = '\0' ;
 	pString->nSize = nStrSize ;
@@ -90,7 +95,7 @@ RING_API void ring_string_add2_gc ( void *pState,String *pString,const char *str
 	assert(pString != NULL);
 	nOriginalSize = ring_string_size(pString) ;
 	x2 = nStrSize+nOriginalSize ;
-	pString->cStr = (char *) ring_state_realloc(pState,pString->cStr,x2+1);
+	pString->cStr = (char *) ring_state_realloc(pState,pString->cStr,nOriginalSize+1,x2+1);
 	if ( pString->cStr  == NULL ) {
 		printf( RING_OOM ) ;
 		exit(0);

--- a/language/src/ring_vm.c
+++ b/language/src/ring_vm.c
@@ -813,7 +813,7 @@ int ring_vm_eval ( VM *pVM,const char *cStr )
 		ring_vm_blockflag2(pVM,nPC);
 		pVM->nPC = nLastPC+1 ;
 		if ( ring_list_getsize(pVM->pCode)  > pVM->nEvalReallocationSize ) {
-			pByteCode = (ByteCode *) ring_state_realloc(pVM->pRingState,pVM->pByteCode , sizeof(ByteCode) * ring_list_getsize(pVM->pCode));
+			pByteCode = (ByteCode *) ring_state_realloc(pVM->pRingState,pVM->pByteCode , sizeof(ByteCode) * pVM->nEvalReallocationSize, sizeof(ByteCode) * ring_list_getsize(pVM->pCode));
 			if ( pByteCode == NULL ) {
 				printf( RING_OOM ) ;
 				printf( "RingVM : Can't Allocate Memory for the Byte Code!\n" ) ;
@@ -925,7 +925,7 @@ void ring_vm_returneval ( VM *pVM )
 		}
 		if ( pVM->nEvalReallocationFlag == 1 ) {
 			pVM->nEvalReallocationFlag = 0 ;
-			pByteCode = (ByteCode *) ring_state_realloc(pVM->pRingState,pVM->pByteCode , sizeof(ByteCode) * ring_list_getsize(pVM->pCode));
+			pByteCode = (ByteCode *) ring_state_realloc(pVM->pRingState,pVM->pByteCode , sizeof(ByteCode) * pVM->nEvalReallocationSize, sizeof(ByteCode) * ring_list_getsize(pVM->pCode));
 			if ( pByteCode == NULL ) {
 				printf( RING_OOM ) ;
 				exit(0);

--- a/language/src/ring_vmgc.c
+++ b/language/src/ring_vmgc.c
@@ -218,7 +218,7 @@ RING_API void * ring_state_calloc ( void *pState,size_t nitems, size_t size )
 	return ring_calloc(nitems,size) ;
 }
 
-RING_API void * ring_state_realloc ( void *pState,void *ptr, size_t size )
+RING_API void * ring_state_realloc ( void *pState,void *ptr, size_t nAllocatedSize, size_t size )
 {
 	#if RING_USEPOOLMANAGER
 	void *pMemory  ;
@@ -235,8 +235,6 @@ RING_API void * ring_state_realloc ( void *pState,void *ptr, size_t size )
 				if ( size <= RING_POOLMANAGER_ITEMSIZE ) {
 					/* pointer belong to memory pool and new size less than RING_POOLMANAGER_ITEMSIZE */
 					/* in this case, just return the same pointer since we have space for new data */
-					/* and update the nAllocatedSize field with the new size */
-					pPoolData->nAllocatedSize = (int) size;
 					return ptr;
 				} else {
 					/* allocate new buffer, copy data to it and then free existing pointer from pool */					
@@ -247,7 +245,7 @@ RING_API void * ring_state_realloc ( void *pState,void *ptr, size_t size )
 						exit(0);
 					}
 					/* copy existing data */
-					for ( x = 0 ; x <  pPoolData->nAllocatedSize ; x++ ) {
+					for ( x = 0 ; x <  nAllocatedSize ; x++ ) {
 						((unsigned char*) pMemory)[x] = ((unsigned char*) ptr)[x];
 					}
 					ring_poolmanager_free(((RingState *) pState),ptr) ;
@@ -351,7 +349,6 @@ void * ring_poolmanager_allocate ( RingState *pRingState,size_t size )
 	/* Get Item from the Pool Manager */
 	if ( pRingState->vPoolManager.pCurrentItem != NULL ) {
 		pMemory = pRingState->vPoolManager.pCurrentItem ;
-		pRingState->vPoolManager.pCurrentItem->nAllocatedSize = (int) size;
 		pRingState->vPoolManager.pCurrentItem = pRingState->vPoolManager.pCurrentItem->pNext ;
 	}
 	/* If no free items, Allocate new item */
@@ -387,7 +384,6 @@ int ring_poolmanager_free ( RingState *pRingState,void *pMemory )
 	PoolData *pPoolData  ;
 	if ( ring_poolmanager_find(pRingState, pMemory) ) {
 		pPoolData = (PoolData *) pMemory ;
-		pPoolData->nAllocatedSize = 0;
 		pPoolData->pNext = pRingState->vPoolManager.pCurrentItem ;
 		pRingState->vPoolManager.pCurrentItem = pPoolData ;
 		#if RING_TRACKALLOCATIONS

--- a/language/src/ring_vmgc.c
+++ b/language/src/ring_vmgc.c
@@ -220,6 +220,43 @@ RING_API void * ring_state_calloc ( void *pState,size_t nitems, size_t size )
 
 RING_API void * ring_state_realloc ( void *pState,void *ptr, size_t size )
 {
+	#if RING_USEPOOLMANAGER
+	void *pMemory  ;
+	PoolData *pPoolData  ;
+	int x ;
+	if ( pState != NULL ) {
+		#if RING_TRACKALLOCATIONS
+		((RingState *) pState)->vPoolManager.nAllocCount++ ;
+		#endif
+		
+		if ( ((RingState *) pState)->pVM != NULL ) {
+			if ( ring_poolmanager_find((RingState *) pState,ptr) ) {
+				pPoolData = (PoolData*) ptr;
+				if ( size <= RING_POOLMANAGER_ITEMSIZE ) {
+					/* pointer belong to memory pool and new size less than RING_POOLMANAGER_ITEMSIZE */
+					/* in this case, just return the same pointer since we have space for new data */
+					/* and update the nAllocatedSize field with the new size */
+					pPoolData->nAllocatedSize = (int) size;
+					return ptr;
+				} else {
+					/* allocate new buffer, copy data to it and then free existing pointer from pool */					
+					pMemory = ring_malloc(size);
+					/* Check Memory */
+					if ( pMemory == NULL ) {
+						printf( RING_OOM ) ;
+						exit(0);
+					}
+					/* copy existing data */
+					for ( x = 0 ; x <  pPoolData->nAllocatedSize ; x++ ) {
+						((unsigned char*) pMemory)[x] = ((unsigned char*) ptr)[x];
+					}
+					ring_poolmanager_free(((RingState *) pState),ptr) ;
+					return pMemory ;
+				}
+			}
+		}
+	}
+	#endif
 	return ring_realloc(ptr,size) ;
 }
 
@@ -314,6 +351,7 @@ void * ring_poolmanager_allocate ( RingState *pRingState,size_t size )
 	/* Get Item from the Pool Manager */
 	if ( pRingState->vPoolManager.pCurrentItem != NULL ) {
 		pMemory = pRingState->vPoolManager.pCurrentItem ;
+		pRingState->vPoolManager.pCurrentItem->nAllocatedSize = (int) size;
 		pRingState->vPoolManager.pCurrentItem = pRingState->vPoolManager.pCurrentItem->pNext ;
 	}
 	/* If no free items, Allocate new item */
@@ -331,21 +369,31 @@ void * ring_poolmanager_allocate ( RingState *pRingState,size_t size )
 	return pMemory ;
 }
 
-int ring_poolmanager_free ( RingState *pRingState,void *pMemory )
+int ring_poolmanager_find ( RingState *pRingState,void *pMemory )
 {
-	PoolData *pPoolData  ;
 	if ( pRingState != NULL ) {
 		if ( pRingState->vPoolManager.pBlockStart != NULL ) {
 			if ( (pMemory >= pRingState->vPoolManager.pBlockStart) && (pMemory <= pRingState->vPoolManager.pBlockEnd ) ) {
-				pPoolData = (PoolData *) pMemory ;
-				pPoolData->pNext = pRingState->vPoolManager.pCurrentItem ;
-				pRingState->vPoolManager.pCurrentItem = pPoolData ;
-				#if RING_TRACKALLOCATIONS
-				pRingState->vPoolManager.nSmallFreeCount++ ;
-				#endif
 				return 1 ;
 			}
 		}
+	}
+	/* Reaching this point means that the Pool Manager doesn't own this memory to free it! */
+	return 0 ;
+}
+
+int ring_poolmanager_free ( RingState *pRingState,void *pMemory )
+{
+	PoolData *pPoolData  ;
+	if ( ring_poolmanager_find(pRingState, pMemory) ) {
+		pPoolData = (PoolData *) pMemory ;
+		pPoolData->nAllocatedSize = 0;
+		pPoolData->pNext = pRingState->vPoolManager.pCurrentItem ;
+		pRingState->vPoolManager.pCurrentItem = pPoolData ;
+		#if RING_TRACKALLOCATIONS
+		pRingState->vPoolManager.nSmallFreeCount++ ;
+		#endif
+		return 1 ;
 	}
 	/* Reaching this point means that the Pool Manager doesn't own this memory to free it! */
 	return 0 ;


### PR DESCRIPTION
The code was using `malloc-copy-free` strategy which is not optimal since C runtime provides an optimized `realloc` implementation that gives huge speedup in scenarios where we need to append data to an existing pointer.
Moreover, the implementation of `ring_state_realloc` was not correct since it didn't handle the case of pointers belonging to the internal memory pool which can cause issues.

The example below demonstrates the performance gain: on Linux 64bit, before change it gives a `8.17` seconds performance and after the change it gives `0.01` seconds.

```
fullStr = "initial"
lineStr = "Dummy content line"

t1 = clock()
for i = 1 to 20000 {
	fullStr+= lineStr
}
t2 = clock()

delta = (t2 - t1) /clockspersecond()

? "total length = " + len(fullStr) + " characters"
? "perf= " + delta + " seconds"
```