### PR TITLE
Fix operator '=' giving wrong result for strings containing binary data

### DIFF
--- a/language/src/ring_vmexpr.c
+++ b/language/src/ring_vmexpr.c
@@ -287,7 +287,7 @@ void ring_vm_equal ( VM *pVM )
 		RING_VM_STACK_POP ;
 		if ( RING_VM_STACK_ISSTRING ) {
 			cStr2 = RING_VM_STACK_GETSTRINGRAW ;
-			if ( strcmp(ring_string_get(cStr1),ring_string_get(cStr2)) == 0 ) {
+			if ( (cStr1->nSize == cStr2->nSize) && (memcmp(ring_string_get(cStr1),ring_string_get(cStr2), cStr1->nSize) == 0) ) {
 				RING_VM_STACK_TRUE ;
 			}
 			else {


### PR DESCRIPTION
The code used `strcmp` to compare strings but if the binary data contains a zero then `strcmp` will have wrong logic.
For example, the program below will wrongly display that `c1` and `c2` are equal in most cases although they are different:

```
load "openssllib.ring"

failures = 0

for i = 1 to 256 {
	c1 = randbytes(256)
	c2 = c1 + randbytes(256)

	if c1 = c2 {
		failures++
	}
}

if failures != 0 {
	? "Error: " + failures + " Tests Failed!!"
else
	? "Test OK"
}

```
A typical output is:

`Error: 158 Tests Failed!!`

This change makes the code use `memcpy` preceded by a check on the string size