### PR TITLE
Use optimized build on Linux and macOS by using -O2 switch for gcc/clang

### DIFF
--- a/extensions/ringallegro/buildclang.sh
+++ b/extensions/ringallegro/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_allegro.c -I $PWD/../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_allegro.c -I $PWD/../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../lib/libringallegro.dylib ring_allegro.o /usr/local/lib/liballegro.dylib /usr/local/lib/liballegro_image.dylib /usr/local/lib/liballegro_dialog.dylib /usr/local/lib/liballegro_ttf.dylib /usr/local/lib/liballegro_acodec.dylib /usr/local/lib/liballegro_audio.dylib /usr/local/lib/liballegro_font.dylib /usr/local/lib/liballegro_primitives.dylib /usr/local/lib/liballegro_color.dylib /usr/local/lib/liballegro_physfs.dylib /usr/local/lib/liballegro_memfile.dylib -L $PWD/../../lib  -lring 
 
  

--- a/extensions/ringallegro/buildgcc.sh
+++ b/extensions/ringallegro/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_allegro.c -I $PWD/../../language/include
+gcc -c -fpic -O2 ring_allegro.c -I $PWD/../../language/include
 gcc -shared -o $PWD/../../lib/libringallegro.so ring_allegro.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lallegro -lallegro_image -lallegro_dialog -lallegro_ttf -lallegro_acodec -lallegro_primitives
 
  

--- a/extensions/ringconsolecolors/buildclang.sh
+++ b/extensions/ringconsolecolors/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_consolecolors.c -I $PWD/../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_consolecolors.c -I $PWD/../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../lib/libring_consolecolors.dylib ring_consolecolors.o  -L $PWD/../../lib  -lring 
 
  

--- a/extensions/ringconsolecolors/buildgcc.sh
+++ b/extensions/ringconsolecolors/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_consolecolors.c -I $PWD/../../language/include
+gcc -c -fpic -O2 ring_consolecolors.c -I $PWD/../../language/include
 gcc -shared -o $PWD/../../lib/libring_consolecolors.so ring_consolecolors.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu
 
  

--- a/extensions/ringcurl/buildclang.sh
+++ b/extensions/ringcurl/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_libcurl.c -I $PWD/../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_libcurl.c -I $PWD/../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../lib/libring_libcurl.dylib ring_libcurl.o  -L $PWD/../../lib  -lring -lcurl -lssl -lcrypto
 
  

--- a/extensions/ringcurl/buildgcc.sh
+++ b/extensions/ringcurl/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_libcurl.c -I $PWD/../../language/include
+gcc -c -fpic -O2 ring_libcurl.c -I $PWD/../../language/include
 gcc -shared -o $PWD/../../lib/libring_libcurl.so ring_libcurl.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lcurl -lssl -lcrypto
 
  

--- a/extensions/ringfreeglut/buildclang.sh
+++ b/extensions/ringfreeglut/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_freeglut.c -I $PWD/../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_freeglut.c -I $PWD/../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../lib/libring_freeglut.dylib ring_freeglut.o -framework OpenGL -framework GLUT -L $PWD/../../lib  -lring 
 
  

--- a/extensions/ringfreeglut/buildgcc.sh
+++ b/extensions/ringfreeglut/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_freeglut.c -I $PWD/../../language/include
+gcc -c -fpic -O2 ring_freeglut.c -I $PWD/../../language/include
 gcc -shared -o $PWD/../../lib/libring_freeglut.so ring_freeglut.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut 
 
  

--- a/extensions/ringinternet/buildclang.sh
+++ b/extensions/ringinternet/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_internet.c -I $PWD/../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_internet.c -I $PWD/../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../lib/libring_internet.dylib ring_internet.o  -L $PWD/../../lib  -lring -lcurl -lssl -lcrypto
 
  

--- a/extensions/ringinternet/buildgcc.sh
+++ b/extensions/ringinternet/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_internet.c -I $PWD/../../language/include
+gcc -c -fpic -O2 ring_internet.c -I $PWD/../../language/include
 gcc -shared -o $PWD/../../lib/libring_internet.so ring_internet.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lcurl -lssl -lcrypto
 
  

--- a/extensions/ringlibuv/buildclang.sh
+++ b/extensions/ringlibuv/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_libuv.c -I $PWD/../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_libuv.c -I $PWD/../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../lib/libring_uv.dylib ring_libuv.o  -L $PWD/../../lib  -lring -luv
 
  

--- a/extensions/ringlibuv/buildgcc.sh
+++ b/extensions/ringlibuv/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_libuv.c -I $PWD/../../language/include
+gcc -c -fpic -O2 ring_libuv.c -I $PWD/../../language/include
 gcc -shared -o $PWD/../../lib/libring_uv.so ring_libuv.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -luv
 
  

--- a/extensions/ringmurmurhash/buildclang.sh
+++ b/extensions/ringmurmurhash/buildclang.sh
@@ -1,10 +1,10 @@
-#clang -c -fpic ring_murmurhash.c libmurmurhash/MurmurHash1.c libmurmurhash/MurmurHash2.c libmurmurhash/MurmurHash3.c -I $PWD/../../language/include -I $PWD/libmurmurhash/
+#clang -c -fpic -O2 ring_murmurhash.c libmurmurhash/MurmurHash1.c libmurmurhash/MurmurHash2.c libmurmurhash/MurmurHash3.c -I $PWD/../../language/include -I $PWD/libmurmurhash/
 #clang -dynamiclib -o $PWD/../../lib/libring_murmurhash.dylib *.o -L $PWD/../../lib  -lring 
 #rm *.o
 
 echo "We will use gcc instead of clang"
 
-gcc -c -fpic ring_murmurhash.c libmurmurhash/MurmurHash1.c \
+gcc -c -fpic -O2 ring_murmurhash.c libmurmurhash/MurmurHash1.c \
     libmurmurhash/MurmurHash2.c libmurmurhash/MurmurHash3.c \
     -g -Wall -O3 -I $PWD/../../language/include -I libmurmurhash/
 

--- a/extensions/ringmurmurhash/buildgcc.sh
+++ b/extensions/ringmurmurhash/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_murmurhash.c libmurmurhash/MurmurHash1.c \
+gcc -c -fpic -O2 ring_murmurhash.c libmurmurhash/MurmurHash1.c \
     libmurmurhash/MurmurHash2.c libmurmurhash/MurmurHash3.c \
     -g -Wall -O3 -I $PWD/../../language/include -I libmurmurhash/
 

--- a/extensions/ringmysql/buildclang.sh
+++ b/extensions/ringmysql/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_vmmysql.c -I $PWD/../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_vmmysql.c -I $PWD/../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../lib/libring_mysql.dylib ring_vmmysql.o  -L $PWD/../../lib  -lring -lmysqlclient
 
  

--- a/extensions/ringmysql/buildgcc.sh
+++ b/extensions/ringmysql/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_vmmysql.c -I $PWD/../../language/include -I /usr/include/mysql 
+gcc -c -fpic -O2 ring_vmmysql.c -I $PWD/../../language/include -I /usr/include/mysql 
 gcc -shared -o $PWD/../../lib/libring_mysql.so ring_vmmysql.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -L /usr/lib/mysql/lib -lmysqlclient
 
  

--- a/extensions/ringmysql/buildgccfedora.sh
+++ b/extensions/ringmysql/buildgccfedora.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_vmmysql.c -I $PWD/../../language/include -I /usr/include/mysql 
+gcc -c -fpic -O2 ring_vmmysql.c -I $PWD/../../language/include -I /usr/include/mysql 
 gcc -shared -o $PWD/../../lib/libring_mysql.so ring_vmmysql.o -L $PWD/../../lib -lring -L /usr/lib64/mysql -L /usr/lib/mysql -lmysqlclient
 
  

--- a/extensions/ringodbc/buildclang.sh
+++ b/extensions/ringodbc/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_vmodbc.c -I $PWD/../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_vmodbc.c -I $PWD/../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../lib/libring_odbc.dylib ring_vmodbc.o  -L $PWD/../../lib  -lring -lodbc 
 
  

--- a/extensions/ringodbc/buildgcc.sh
+++ b/extensions/ringodbc/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_vmodbc.c -I $PWD/../../language/include
+gcc -c -fpic -O2 ring_vmodbc.c -I $PWD/../../language/include
 gcc -shared -o $PWD/../../lib/libring_odbc.so ring_vmodbc.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lodbc
 
  

--- a/extensions/ringopengl/opengl11/buildclang.sh
+++ b/extensions/ringopengl/opengl11/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl11.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl11.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl11.dylib ring_opengl11.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl11/buildgcc.sh
+++ b/extensions/ringopengl/opengl11/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl11.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl11.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl11.so ring_opengl11.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl12/buildclang.sh
+++ b/extensions/ringopengl/opengl12/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl12.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl12.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl12.dylib ring_opengl12.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl12/buildgcc.sh
+++ b/extensions/ringopengl/opengl12/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl12.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl12.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl12.so ring_opengl12.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl13/buildclang.sh
+++ b/extensions/ringopengl/opengl13/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl13.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl13.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl13.dylib ring_opengl13.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl13/buildgcc.sh
+++ b/extensions/ringopengl/opengl13/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl13.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl13.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl13.so ring_opengl13.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl14/buildclang.sh
+++ b/extensions/ringopengl/opengl14/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl14.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl14.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl14.dylib ring_opengl14.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl14/buildgcc.sh
+++ b/extensions/ringopengl/opengl14/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl14.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl14.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl14.so ring_opengl14.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl15/buildclang.sh
+++ b/extensions/ringopengl/opengl15/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl15.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl15.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl15.dylib ring_opengl15.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl15/buildgcc.sh
+++ b/extensions/ringopengl/opengl15/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl15.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl15.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl15.so ring_opengl15.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl20/buildclang.sh
+++ b/extensions/ringopengl/opengl20/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl20.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl20.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl20.dylib ring_opengl20.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl20/buildgcc.sh
+++ b/extensions/ringopengl/opengl20/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl20.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl20.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl20.so ring_opengl20.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl21/buildclang.sh
+++ b/extensions/ringopengl/opengl21/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl21.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl21.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl21.dylib ring_opengl21.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl21/buildgcc.sh
+++ b/extensions/ringopengl/opengl21/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl21.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl21.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl21.so ring_opengl21.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl30/buildclang.sh
+++ b/extensions/ringopengl/opengl30/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl30.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl30.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl30.dylib ring_opengl30.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl30/buildgcc.sh
+++ b/extensions/ringopengl/opengl30/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl30.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl30.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl30.so ring_opengl30.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl31/buildclang.sh
+++ b/extensions/ringopengl/opengl31/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl31.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl31.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl31.dylib ring_opengl31.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl31/buildgcc.sh
+++ b/extensions/ringopengl/opengl31/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl31.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl31.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl31.so ring_opengl31.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl32/buildclang.sh
+++ b/extensions/ringopengl/opengl32/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl32.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl32.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl32.dylib ring_opengl32.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl32/buildgcc.sh
+++ b/extensions/ringopengl/opengl32/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl32.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl32.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl32.so ring_opengl32.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl33/buildclang.sh
+++ b/extensions/ringopengl/opengl33/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl33.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl33.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl33.dylib ring_opengl33.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl33/buildgcc.sh
+++ b/extensions/ringopengl/opengl33/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl33.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl33.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl33.so ring_opengl33.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl40/buildclang.sh
+++ b/extensions/ringopengl/opengl40/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl40.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl40.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl40.dylib ring_opengl40.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl40/buildgcc.sh
+++ b/extensions/ringopengl/opengl40/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl40.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl40.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl40.so ring_opengl40.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl41/buildclang.sh
+++ b/extensions/ringopengl/opengl41/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl41.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl41.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl41.dylib ring_opengl41.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl41/buildgcc.sh
+++ b/extensions/ringopengl/opengl41/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl41.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl41.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl41.so ring_opengl41.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl42/buildclang.sh
+++ b/extensions/ringopengl/opengl42/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl42.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl42.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl42.dylib ring_opengl42.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl42/buildgcc.sh
+++ b/extensions/ringopengl/opengl42/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl42.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl42.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl42.so ring_opengl42.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl43/buildclang.sh
+++ b/extensions/ringopengl/opengl43/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl43.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl43.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl43.dylib ring_opengl43.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl43/buildgcc.sh
+++ b/extensions/ringopengl/opengl43/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl43.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl43.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl43.so ring_opengl43.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl44/buildclang.sh
+++ b/extensions/ringopengl/opengl44/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl44.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl44.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl44.dylib ring_opengl44.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl44/buildgcc.sh
+++ b/extensions/ringopengl/opengl44/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl44.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl44.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl44.so ring_opengl44.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl45/buildclang.sh
+++ b/extensions/ringopengl/opengl45/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl45.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl45.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl45.dylib ring_opengl45.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl45/buildgcc.sh
+++ b/extensions/ringopengl/opengl45/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl45.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl45.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl45.so ring_opengl45.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopengl/opengl46/buildclang.sh
+++ b/extensions/ringopengl/opengl46/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_opengl46.c -I $PWD/../../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_opengl46.c -I $PWD/../../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../../lib/libring_opengl46.dylib ring_opengl46.o /usr/local/lib/libglew.dylib -framework OpenGL -framework GLUT -L $PWD/../../../lib  -lring 
 
  

--- a/extensions/ringopengl/opengl46/buildgcc.sh
+++ b/extensions/ringopengl/opengl46/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_opengl46.c -I $PWD/../../../language/include
+gcc -c -fpic -O2 ring_opengl46.c -I $PWD/../../../language/include
 gcc -shared -o $PWD/../../../lib/libring_opengl46.so ring_opengl46.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lGL -lGLU -lglut
 
  

--- a/extensions/ringopenssl/buildclang.sh
+++ b/extensions/ringopenssl/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_vmopenssl.c -I $PWD/../../language/include -I /usr/local/include -I /usr/local/opt/openssl/include
+clang -c -fpic -O2 ring_vmopenssl.c -I $PWD/../../language/include -I /usr/local/include -I /usr/local/opt/openssl/include
 clang -dynamiclib -o $PWD/../../lib/libring_openssl.dylib ring_vmopenssl.o  -L $PWD/../../lib  -lring -lssl -lcrypto
 
  

--- a/extensions/ringopenssl/buildgcc.sh
+++ b/extensions/ringopenssl/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_vmopenssl.c -I $PWD/../../language/include
+gcc -c -fpic -O2 ring_vmopenssl.c -I $PWD/../../language/include
 gcc -shared -o $PWD/../../lib/libring_openssl.so ring_vmopenssl.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -lssl -lcrypto
 
  

--- a/extensions/ringpostgresql/buildclang.sh
+++ b/extensions/ringpostgresql/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_pgsql.c -I $PWD/../../language/include -I /usr/local/include -I /usr/local/opt/libpq/include
+clang -c -fpic -O2 ring_pgsql.c -I $PWD/../../language/include -I /usr/local/include -I /usr/local/opt/libpq/include
 clang -dynamiclib -o $PWD/../../lib/libring_pgsql.dylib ring_pgsql.o -L $PWD/../../lib  -lring  -L /usr/local/opt/libpq/lib  -lpq
 
  

--- a/extensions/ringpostgresql/buildgcc.sh
+++ b/extensions/ringpostgresql/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_pgsql.c -I $PWD/../../language/include -I /usr/include/postgresql
+gcc -c -fpic -O2 ring_pgsql.c -I $PWD/../../language/include -I /usr/include/postgresql
 gcc -shared -o $PWD/../../lib/libring_pgsql.so ring_pgsql.o -L $PWD/../../lib -lring -L /usr/local/pgsql/lib -lpq 
 
  

--- a/extensions/ringraylib/src/buildgcc.sh
+++ b/extensions/ringraylib/src/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_raylib.c -I $PWD/../../../language/include -I linux_raylib-2.5/include
+gcc -c -fpic -O2 ring_raylib.c -I $PWD/../../../language/include -I linux_raylib-2.5/include
 gcc -shared -o $PWD/../../../lib/libringraylib.so ring_raylib.o -L $PWD/../../../lib -lring -L $PWD/linux_raylib-2.5/lib -lraylib
 
  

--- a/extensions/ringraylib/src/buildgccmac.sh
+++ b/extensions/ringraylib/src/buildgccmac.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_raylib.c -I $PWD/../../../language/include -I macOS_raylib-2.5/include
+gcc -c -fpic -O2 ring_raylib.c -I $PWD/../../../language/include -I macOS_raylib-2.5/include
 gcc -shared -o $PWD/../../../lib/libringraylib.dylib ring_raylib.o -L $PWD/../../../lib -lring -L $PWD/macOS_raylib-2.5/lib -lraylib
 
  

--- a/extensions/ringsdl/buildgcc.sh
+++ b/extensions/ringsdl/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_libsdl.c -I $PWD/../../language/include -I /usr/include/SDL2
+gcc -c -fpic -O2 ring_libsdl.c -I $PWD/../../language/include -I /usr/include/SDL2
 gcc -shared -o $PWD/../../lib/libringsdl.so ring_libsdl.o -L $PWD/../../lib -lring `pkg-config --cflags --libs sdl2`
 
  

--- a/extensions/ringsqlite/buildclang.sh
+++ b/extensions/ringsqlite/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_vmsqlite.c sqlite3.c -I $PWD/../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_vmsqlite.c sqlite3.c -I $PWD/../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../lib/libring_sqlite.dylib ring_vmsqlite.o sqlite3.o -L $PWD/../../lib  -lring 
  
 

--- a/extensions/ringsqlite/buildgcc.sh
+++ b/extensions/ringsqlite/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_vmsqlite.c sqlite3.c -I $PWD/../../language/include
+gcc -c -fpic -O2 ring_vmsqlite.c sqlite3.c -I $PWD/../../language/include
 gcc -shared -o $PWD/../../lib/libring_sqlite.so ring_vmsqlite.o sqlite3.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu -pthread
 
  

--- a/extensions/ringstbimage/buildclang.sh
+++ b/extensions/ringstbimage/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_stbimage.c -I $PWD/../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_stbimage.c -I $PWD/../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../lib/libring_stbimage.dylib ring_stbimage.o  -L $PWD/../../lib  -lring 
 
  

--- a/extensions/ringstbimage/buildgcc.sh
+++ b/extensions/ringstbimage/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_stbimage.c -I $PWD/../../language/include
+gcc -c -fpic -O2 ring_stbimage.c -I $PWD/../../language/include
 gcc -shared -o $PWD/../../lib/libring_stbimage.so ring_stbimage.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu
 
  

--- a/extensions/ringzip/buildclang.sh
+++ b/extensions/ringzip/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ring_libzip.c -I $PWD/../../language/include -I /usr/local/include
+clang -c -fpic -O2 ring_libzip.c -I $PWD/../../language/include -I /usr/local/include
 clang -dynamiclib -o $PWD/../../lib/libring_libzip.dylib ring_libzip.o  -L $PWD/../../lib  -lring 
 
  

--- a/extensions/ringzip/buildgcc.sh
+++ b/extensions/ringzip/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ring_libzip.c -I $PWD/../../language/include
+gcc -c -fpic -O2 ring_libzip.c -I $PWD/../../language/include
 gcc -shared -o $PWD/../../lib/libring_libzip.so ring_libzip.o -L $PWD/../../lib -lring -L /usr/lib/i386-linux-gnu
 
  

--- a/extensions/socket/buildclang.sh
+++ b/extensions/socket/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic ext/socket.c -I $PWD/../../../include
+clang -c -fpic -O2 ext/socket.c -I $PWD/../../../include
 clang -dynamiclib -o socketlib.dylib socket.o  -L $PWD/../../../lib  -lring
 cp socketlib.dylib /usr/local/lib
 

--- a/extensions/socket/buildgcc.sh
+++ b/extensions/socket/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic ext/socket.c -o socket.o -I ../../../ring/language/include/
+gcc -c -fpic -O2 ext/socket.c -o socket.o -I ../../../ring/language/include/
 gcc -shared -o socket.so socket.o -L ../../../ring/lib/ -lring
 sudo cp socket.so /usr/lib/
 sudo cp socket.so /usr/lib64/

--- a/extensions/tutorial/createtable/buildclang.sh
+++ b/extensions/tutorial/createtable/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic mylib.c -I $PWD/../../../language/include
+clang -c -fpic -O2 mylib.c -I $PWD/../../../language/include
 clang -dynamiclib -o libmylib.dylib mylib.o  -L $PWD/../../../lib  -lring
 cp libmylib.dylib /usr/local/lib
  

--- a/extensions/tutorial/createtable/buildgcc.sh
+++ b/extensions/tutorial/createtable/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic mylib.c -I $PWD/../../../language/include 
+gcc -c -fpic -O2 mylib.c -I $PWD/../../../language/include 
 gcc -shared -o libmylib.so mylib.o -L $PWD/../../../lib -lring
 sudo cp libmylib.so /usr/lib
 sudo cp libmylib.so /usr/lib64

--- a/extensions/tutorial/displaylist/buildclang.sh
+++ b/extensions/tutorial/displaylist/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic mylib.c -I $PWD/../../../language/include
+clang -c -fpic -O2 mylib.c -I $PWD/../../../language/include
 clang -dynamiclib -o libmylib.dylib mylib.o  -L $PWD/../../../lib  -lring
 cp libmylib.dylib /usr/local/lib
  

--- a/extensions/tutorial/displaylist/buildgcc.sh
+++ b/extensions/tutorial/displaylist/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic mylib.c -I $PWD/../../../language/include 
+gcc -c -fpic -O2 mylib.c -I $PWD/../../../language/include 
 gcc -shared -o libmylib.so mylib.o -L $PWD/../../../lib -lring
 sudo cp libmylib.so /usr/lib
 sudo cp libmylib.so /usr/lib64

--- a/extensions/tutorial/filterlist/buildclang.sh
+++ b/extensions/tutorial/filterlist/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic mylib.c -I $PWD/../../../language/include
+clang -c -fpic -O2 mylib.c -I $PWD/../../../language/include
 clang -dynamiclib -o libmylib.dylib mylib.o  -L $PWD/../../../lib  -lring
 cp libmylib.dylib /usr/local/lib
  

--- a/extensions/tutorial/filterlist/buildgcc.sh
+++ b/extensions/tutorial/filterlist/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic mylib.c -I $PWD/../../../language/include 
+gcc -c -fpic -O2 mylib.c -I $PWD/../../../language/include 
 gcc -shared -o libmylib.so mylib.o -L $PWD/../../../lib -lring
 sudo cp libmylib.so /usr/lib
 sudo cp libmylib.so /usr/lib64

--- a/extensions/tutorial/generatelist/buildclang.sh
+++ b/extensions/tutorial/generatelist/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic mylib.c -I $PWD/../../../language/include
+clang -c -fpic -O2 mylib.c -I $PWD/../../../language/include
 clang -dynamiclib -o libmylib.dylib mylib.o  -L $PWD/../../../lib  -lring
 cp libmylib.dylib /usr/local/lib
  

--- a/extensions/tutorial/generatelist/buildgcc.sh
+++ b/extensions/tutorial/generatelist/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic mylib.c -I $PWD/../../../language/include 
+gcc -c -fpic -O2 mylib.c -I $PWD/../../../language/include 
 gcc -shared -o libmylib.so mylib.o -L $PWD/../../../lib -lring
 sudo cp libmylib.so /usr/lib
 sudo cp libmylib.so /usr/lib64

--- a/extensions/tutorial/helloworld2/buildclang.sh
+++ b/extensions/tutorial/helloworld2/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic mylib.c -I $PWD/../../../language/include
+clang -c -fpic -O2 mylib.c -I $PWD/../../../language/include
 clang -dynamiclib -o libmylib.dylib mylib.o  -L $PWD/../../../lib  -lring
 cp libmylib.dylib /usr/local/lib
  

--- a/extensions/tutorial/helloworld2/buildgcc.sh
+++ b/extensions/tutorial/helloworld2/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic mylib.c -I $PWD/../../../language/include 
+gcc -c -fpic -O2 mylib.c -I $PWD/../../../language/include 
 gcc -shared -o libmylib.so mylib.o -L $PWD/../../../lib -lring
 sudo cp libmylib.so /usr/lib
 sudo cp libmylib.so /usr/lib64

--- a/extensions/tutorial/incrementlist/buildclang.sh
+++ b/extensions/tutorial/incrementlist/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic mylib.c -I $PWD/../../../language/include
+clang -c -fpic -O2 mylib.c -I $PWD/../../../language/include
 clang -dynamiclib -o libmylib.dylib mylib.o  -L $PWD/../../../lib  -lring
 cp libmylib.dylib /usr/local/lib
  

--- a/extensions/tutorial/incrementlist/buildgcc.sh
+++ b/extensions/tutorial/incrementlist/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic mylib.c -I $PWD/../../../language/include 
+gcc -c -fpic -O2 mylib.c -I $PWD/../../../language/include 
 gcc -shared -o libmylib.so mylib.o -L $PWD/../../../lib -lring
 sudo cp libmylib.so /usr/lib
 sudo cp libmylib.so /usr/lib64

--- a/extensions/tutorial/replicatelist/buildclang.sh
+++ b/extensions/tutorial/replicatelist/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic mylib.c -I $PWD/../../../language/include
+clang -c -fpic -O2 mylib.c -I $PWD/../../../language/include
 clang -dynamiclib -o libmylib.dylib mylib.o  -L $PWD/../../../lib  -lring
 cp libmylib.dylib /usr/local/lib
  

--- a/extensions/tutorial/replicatelist/buildgcc.sh
+++ b/extensions/tutorial/replicatelist/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic mylib.c -I $PWD/../../../language/include 
+gcc -c -fpic -O2 mylib.c -I $PWD/../../../language/include 
 gcc -shared -o libmylib.so mylib.o -L $PWD/../../../lib -lring
 sudo cp libmylib.so /usr/lib
 sudo cp libmylib.so /usr/lib64

--- a/extensions/tutorial/sayhello/buildclang.sh
+++ b/extensions/tutorial/sayhello/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic mylib.c -I $PWD/../../../language/include
+clang -c -fpic -O2 mylib.c -I $PWD/../../../language/include
 clang -dynamiclib -o libmylib.dylib mylib.o  -L $PWD/../../../lib  -lring
 cp libmylib.dylib /usr/local/lib
  

--- a/extensions/tutorial/sayhello/buildgcc.sh
+++ b/extensions/tutorial/sayhello/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic mylib.c -I $PWD/../../../language/include 
+gcc -c -fpic -O2 mylib.c -I $PWD/../../../language/include 
 gcc -shared -o libmylib.so mylib.o -L $PWD/../../../lib -lring
 sudo cp libmylib.so /usr/lib
 sudo cp libmylib.so /usr/lib64

--- a/extensions/tutorial/sumlist/buildclang.sh
+++ b/extensions/tutorial/sumlist/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic mylib.c -I $PWD/../../../language/include
+clang -c -fpic -O2 mylib.c -I $PWD/../../../language/include
 clang -dynamiclib -o libmylib.dylib mylib.o  -L $PWD/../../../lib  -lring
 cp libmylib.dylib /usr/local/lib
  

--- a/extensions/tutorial/sumlist/buildgcc.sh
+++ b/extensions/tutorial/sumlist/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic mylib.c -I $PWD/../../../language/include 
+gcc -c -fpic -O2 mylib.c -I $PWD/../../../language/include 
 gcc -shared -o libmylib.so mylib.o -L $PWD/../../../lib -lring
 sudo cp libmylib.so /usr/lib
 sudo cp libmylib.so /usr/lib64

--- a/extensions/tutorial/sumtwonumbers/buildclang.sh
+++ b/extensions/tutorial/sumtwonumbers/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic mylib.c -I $PWD/../../../language/include
+clang -c -fpic -O2 mylib.c -I $PWD/../../../language/include
 clang -dynamiclib -o libmylib.dylib mylib.o  -L $PWD/../../../lib  -lring
 cp libmylib.dylib /usr/local/lib
  

--- a/extensions/tutorial/sumtwonumbers/buildgcc.sh
+++ b/extensions/tutorial/sumtwonumbers/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic mylib.c -I $PWD/../../../language/include 
+gcc -c -fpic -O2 mylib.c -I $PWD/../../../language/include 
 gcc -shared -o libmylib.so mylib.o -L $PWD/../../../lib -lring
 sudo cp libmylib.so /usr/lib
 sudo cp libmylib.so /usr/lib64

--- a/extensions/tutorial/updatetable/buildclang.sh
+++ b/extensions/tutorial/updatetable/buildclang.sh
@@ -1,4 +1,4 @@
-clang -c -fpic mylib.c -I $PWD/../../../language/include
+clang -c -fpic -O2 mylib.c -I $PWD/../../../language/include
 clang -dynamiclib -o libmylib.dylib mylib.o  -L $PWD/../../../lib  -lring
 cp libmylib.dylib /usr/local/lib
  

--- a/extensions/tutorial/updatetable/buildgcc.sh
+++ b/extensions/tutorial/updatetable/buildgcc.sh
@@ -1,4 +1,4 @@
-gcc -c -fpic mylib.c -I $PWD/../../../language/include 
+gcc -c -fpic -O2 mylib.c -I $PWD/../../../language/include 
 gcc -shared -o libmylib.so mylib.o -L $PWD/../../../lib -lring
 sudo cp libmylib.so /usr/lib
 sudo cp libmylib.so /usr/lib64

--- a/language/src/buildclang.sh
+++ b/language/src/buildclang.sh
@@ -1,12 +1,12 @@
 clear
-clang -c -fpic ring_state.c ring_ext.c ring_hashlib.c ring_hashtable.c ring_vmgc.c ring_vmos.c ring_string.c ring_list.c ring_item.c ring_items.c ring_scanner.c ring_parser.c ring_stmt.c ring_expr.c ring_codegen.c ring_vm.c ring_vmexpr.c ring_vmvars.c ring_vmlists.c ring_vmfuncs.c ring_api.c ring_vmoop.c ring_vmcui.c ring_vmtrycatch.c ring_vmstrindex.c ring_vmjump.c ring_vmduprange.c ring_vmlistfuncs.c ring_vmrefmeta.c ring_vmperformance.c ring_vmexit.c ring_vmstackvars.c ring_vmstate.c ring_vmmath.c ring_vmfile.c ring_vmdll.c ring_objfile.c -I $PWD/../include 
+clang -c -fpic -O2 ring_state.c ring_ext.c ring_hashlib.c ring_hashtable.c ring_vmgc.c ring_vmos.c ring_string.c ring_list.c ring_item.c ring_items.c ring_scanner.c ring_parser.c ring_stmt.c ring_expr.c ring_codegen.c ring_vm.c ring_vmexpr.c ring_vmvars.c ring_vmlists.c ring_vmfuncs.c ring_api.c ring_vmoop.c ring_vmcui.c ring_vmtrycatch.c ring_vmstrindex.c ring_vmjump.c ring_vmduprange.c ring_vmlistfuncs.c ring_vmrefmeta.c ring_vmperformance.c ring_vmexit.c ring_vmstackvars.c ring_vmstate.c ring_vmmath.c ring_vmfile.c ring_vmdll.c ring_objfile.c -I $PWD/../include 
 
 
 clang -dynamiclib -o $PWD/../../lib/libring.dylib ring_state.o ring_ext.o ring_hashlib.o ring_hashtable.o ring_vmgc.o ring_vmos.o ring_string.o ring_list.o ring_item.o ring_items.o ring_scanner.o ring_parser.o ring_stmt.o ring_expr.o ring_codegen.o ring_vm.o ring_vmexpr.o ring_vmvars.o ring_vmlists.o ring_vmfuncs.o ring_api.o ring_vmoop.o ring_vmcui.o ring_vmtrycatch.o ring_vmstrindex.o ring_vmjump.o ring_vmduprange.o ring_vmlistfuncs.o ring_vmrefmeta.o ring_vmperformance.o ring_vmexit.o ring_vmstackvars.o ring_vmstate.o ring_vmmath.o ring_vmfile.o ring_vmdll.o ring_objfile.o -lm -ldl  
 
 ar rcs $PWD/../../lib/libringstatic.a ring_state.o ring_ext.o ring_hashlib.o ring_hashtable.o ring_vmgc.o ring_vmos.o ring_string.o ring_list.o ring_item.o ring_items.o ring_scanner.o ring_parser.o ring_stmt.o ring_expr.o ring_codegen.o ring_vm.o ring_vmexpr.o ring_vmvars.o ring_vmlists.o ring_vmfuncs.o ring_api.o ring_vmoop.o ring_vmcui.o ring_vmtrycatch.o ring_vmstrindex.o ring_vmjump.o ring_vmduprange.o ring_vmlistfuncs.o ring_vmrefmeta.o ring_vmperformance.o ring_vmexit.o ring_vmstackvars.o ring_vmstate.o ring_vmmath.o ring_vmfile.o ring_vmdll.o  ring_objfile.o
 
-clang ring.c $PWD/../../lib/libring.dylib -o $PWD/../../bin/ring -L $PWD/../../lib  -I $PWD/../include 
+clang -O2 ring.c $PWD/../../lib/libring.dylib -o $PWD/../../bin/ring -L $PWD/../../lib  -I $PWD/../include 
 
 cd ../../bin
 sudo ./install.sh

--- a/language/src/buildclangstatic.sh
+++ b/language/src/buildclangstatic.sh
@@ -1,5 +1,5 @@
 clear
-clang ring.c ring_state.c ring_ext.c ring_hashlib.c ring_hashtable.c ring_vmgc.c ring_vmos.c ring_string.c ring_list.c ring_item.c ring_items.c ring_scanner.c ring_parser.c ring_stmt.c ring_expr.c ring_codegen.c ring_vm.c ring_vmexpr.c ring_vmvars.c ring_vmlists.c ring_vmfuncs.c ring_api.c ring_vmoop.c ring_vmcui.c ring_vmtrycatch.c ring_vmstrindex.c ring_vmjump.c ring_vmduprange.c ring_vmlistfuncs.c ring_vmrefmeta.c ring_vmperformance.c ring_vmexit.c ring_vmstackvars.c ring_vmstate.c ring_vmmath.c ring_vmfile.c ring_vmdll.c ring_objfile.c -I $PWD/../include -lm -ldl  
+clang -O2 ring.c ring_state.c ring_ext.c ring_hashlib.c ring_hashtable.c ring_vmgc.c ring_vmos.c ring_string.c ring_list.c ring_item.c ring_items.c ring_scanner.c ring_parser.c ring_stmt.c ring_expr.c ring_codegen.c ring_vm.c ring_vmexpr.c ring_vmvars.c ring_vmlists.c ring_vmfuncs.c ring_api.c ring_vmoop.c ring_vmcui.c ring_vmtrycatch.c ring_vmstrindex.c ring_vmjump.c ring_vmduprange.c ring_vmlistfuncs.c ring_vmrefmeta.c ring_vmperformance.c ring_vmexit.c ring_vmstackvars.c ring_vmstate.c ring_vmmath.c ring_vmfile.c ring_vmdll.c ring_objfile.c -I $PWD/../include -lm -ldl  
 
 cd ../../bin
 sudo ./install.sh

--- a/language/src/buildgcc.sh
+++ b/language/src/buildgcc.sh
@@ -1,11 +1,11 @@
 clear
-gcc -c -fpic ring_state.c ring_ext.c ring_hashlib.c ring_hashtable.c ring_vmgc.c ring_vmos.c ring_string.c ring_list.c ring_item.c ring_items.c ring_scanner.c ring_parser.c ring_stmt.c ring_expr.c ring_codegen.c ring_vm.c ring_vmexpr.c ring_vmvars.c ring_vmlists.c ring_vmfuncs.c ring_api.c ring_vmoop.c ring_vmcui.c ring_vmtrycatch.c ring_vmstrindex.c ring_vmjump.c ring_vmduprange.c ring_vmlistfuncs.c ring_vmrefmeta.c ring_vmperformance.c ring_vmexit.c ring_vmstackvars.c ring_vmstate.c ring_vmmath.c ring_vmfile.c ring_vmdll.c ring_objfile.c -I $PWD/../include 
+gcc -c -fpic -O2 ring_state.c ring_ext.c ring_hashlib.c ring_hashtable.c ring_vmgc.c ring_vmos.c ring_string.c ring_list.c ring_item.c ring_items.c ring_scanner.c ring_parser.c ring_stmt.c ring_expr.c ring_codegen.c ring_vm.c ring_vmexpr.c ring_vmvars.c ring_vmlists.c ring_vmfuncs.c ring_api.c ring_vmoop.c ring_vmcui.c ring_vmtrycatch.c ring_vmstrindex.c ring_vmjump.c ring_vmduprange.c ring_vmlistfuncs.c ring_vmrefmeta.c ring_vmperformance.c ring_vmexit.c ring_vmstackvars.c ring_vmstate.c ring_vmmath.c ring_vmfile.c ring_vmdll.c ring_objfile.c -I $PWD/../include 
 
 gcc -shared -o $PWD/../../lib/libring.so ring_state.o ring_ext.o ring_hashlib.o ring_hashtable.o ring_vmgc.o ring_vmos.o ring_string.o ring_list.o ring_item.o ring_items.o ring_scanner.o ring_parser.o ring_stmt.o ring_expr.o ring_codegen.o ring_vm.o ring_vmexpr.o ring_vmvars.o ring_vmlists.o ring_vmfuncs.o ring_api.o ring_vmoop.o ring_vmcui.o ring_vmtrycatch.o ring_vmstrindex.o ring_vmjump.o ring_vmduprange.o ring_vmlistfuncs.o ring_vmrefmeta.o ring_vmperformance.o ring_vmexit.o ring_vmstackvars.o ring_vmstate.o ring_vmmath.o ring_vmfile.o ring_vmdll.o  ring_objfile.o -lm -ldl  
 
 ar rcs $PWD/../../lib/libringstatic.a ring_state.o ring_ext.o ring_hashlib.o ring_hashtable.o ring_vmgc.o ring_vmos.o ring_string.o ring_list.o ring_item.o ring_items.o ring_scanner.o ring_parser.o ring_stmt.o ring_expr.o ring_codegen.o ring_vm.o ring_vmexpr.o ring_vmvars.o ring_vmlists.o ring_vmfuncs.o ring_api.o ring_vmoop.o ring_vmcui.o ring_vmtrycatch.o ring_vmstrindex.o ring_vmjump.o ring_vmduprange.o ring_vmlistfuncs.o ring_vmrefmeta.o ring_vmperformance.o ring_vmexit.o ring_vmstackvars.o ring_vmstate.o ring_vmmath.o ring_vmfile.o ring_vmdll.o  ring_objfile.o
 
-gcc -rdynamic ring.c -o $PWD/../../bin/ring -L $PWD/../../lib -lring  -I $PWD/../include
+gcc -O2 -rdynamic ring.c -o $PWD/../../bin/ring -L $PWD/../../lib -lring  -I $PWD/../include
 
 cd ../../bin
 sudo ./install.sh

--- a/language/src/buildgccstatic.sh
+++ b/language/src/buildgccstatic.sh
@@ -1,5 +1,5 @@
 clear
-gcc ring.c ring_state.c ring_ext.c ring_hashlib.c ring_hashtable.c ring_vmgc.c ring_vmos.c ring_string.c ring_list.c ring_item.c ring_items.c ring_scanner.c ring_parser.c ring_stmt.c ring_expr.c ring_codegen.c ring_vm.c ring_vmexpr.c ring_vmvars.c ring_vmlists.c ring_vmfuncs.c ring_api.c ring_vmoop.c ring_vmcui.c ring_vmtrycatch.c ring_vmstrindex.c ring_vmjump.c ring_vmduprange.c ring_vmlistfuncs.c ring_vmrefmeta.c ring_vmperformance.c ring_vmexit.c ring_vmstackvars.c ring_vmstate.c ring_vmmath.c ring_vmfile.c ring_vmdll.c ring_objfile.c -I $PWD/../include -o $PWD/../../bin/ring -lm -ldl
+gcc -O2 ring.c ring_state.c ring_ext.c ring_hashlib.c ring_hashtable.c ring_vmgc.c ring_vmos.c ring_string.c ring_list.c ring_item.c ring_items.c ring_scanner.c ring_parser.c ring_stmt.c ring_expr.c ring_codegen.c ring_vm.c ring_vmexpr.c ring_vmvars.c ring_vmlists.c ring_vmfuncs.c ring_api.c ring_vmoop.c ring_vmcui.c ring_vmtrycatch.c ring_vmstrindex.c ring_vmjump.c ring_vmduprange.c ring_vmlistfuncs.c ring_vmrefmeta.c ring_vmperformance.c ring_vmexit.c ring_vmstackvars.c ring_vmstate.c ring_vmmath.c ring_vmfile.c ring_vmdll.c ring_objfile.c -I $PWD/../include -o $PWD/../../bin/ring -lm -ldl
 
 cd ../../bin
 sudo ./install.sh

--- a/tools/ring2exe/ring2exe.ring
+++ b/tools/ring2exe/ring2exe.ring
@@ -277,14 +277,14 @@ func GenerateBatchGeneral aPara,aOptions
 		cWindowsBatch = cFile+"_buildvc.bat"
 		write(cWindowsBatch,cCode)
 	# Generate Linux Script (GNU C/C++)
-		cCode = 'gcc -rdynamic #{f1}.c -o #{f1} #{f2} -lm -ldl  -I #{f3}/../language/include  '
+		cCode = 'gcc -rdynamic -O2 #{f1}.c -o #{f1} #{f2} -lm -ldl  -I #{f3}/../language/include  '
 		cCode = substr(cCode,"#{f1}",cFile)
 		cCode = substr(cCode,"#{f2}",aPara[:ringlib][:linux])
 		cCode = substr(cCode,"#{f3}",exefolder())
 		cLinuxBatch = cFile+"_buildgcc.sh"
 		write(cLinuxBatch,cCode)
 	# Generate MacOS X Script (CLang C/C++)
-		cCode = 'clang #{f1}.c #{f2} -o #{f1} -lm -ldl  -I #{f3}/../language/include  '
+		cCode = 'clang -O2 #{f1}.c #{f2} -o #{f1} -lm -ldl  -I #{f3}/../language/include  '
 		cCode = substr(cCode,"#{f1}",cFile)
 		cCode = substr(cCode,"#{f2}",aPara[:ringlib][:macosx])
 		cCode = substr(cCode,"#{f3}",exefolder())


### PR DESCRIPTION
We also modify function `GenerateBatchGeneral` ring2exe.ring to add `-O2` switch to generated build scripts.