### PR TITLE
Add functions sysset/sysunset used to create/modify/delete an environment variable

### DIFF
--- a/language/include/ring_api.h
+++ b/language/include/ring_api.h
@@ -61,6 +61,10 @@
 	void ring_vmlib_del ( void *pPointer ) ;
 
 	void ring_vmlib_get ( void *pPointer ) ;
+	
+	void ring_vmlib_set ( void *pPointer ) ;
+
+	void ring_vmlib_unset ( void *pPointer ) ;
 
 	void ring_vmlib_clock ( void *pPointer ) ;
 


### PR DESCRIPTION
`sysset` is equivalent to the standard C `setenv` function except that it doesn't have a parameter to control if we overwrite or not an existing variable (in our case, we always overwrite since the user can check its existence using `sysget`)
`sysunset` is equivalent to the standard C `unsetenv`

### **SysSet() Function**

We can set environment variables using the SysSet() function

**Syntax:**

SysSet(cVariable, cValue) ---> Returns 1 for success and return 0 for failure

**Example:**

```
pathEnv = sysget("PATH")
d = exefolder()
if IsWindows() {
  path = d + ";" + path
else
  path = d + ":" + path
}
sysset("path")
```

### **SysUnset() Function**

We can delete an environment variables using the SysUnset() function

**Syntax:**

SysUnset(cVariable) ---> Returns 1 for success and return 0 for failure

**Example:**

```
tmpEnv = sysget("TEMP_VAR")
if len(tmpEnv) {
  sysunset("TEMP_VAR")
}
```