### PR TITLE
Fix bug in isWindows64 and add function getarch to return architecture of the Ring executable

### DIFF
--- a/language/include/ring_vmos.h
+++ b/language/include/ring_vmos.h
@@ -30,6 +30,8 @@
 	void ring_vm_os_chdir ( void *pPointer ) ;
 
 	void ring_vm_os_exefolder ( void *pPointer ) ;
+
+	void ring_vm_os_getarch ( void *pPointer ) ;
 	/* Constants */
 	#define RING_VM_POINTER_LIBNAME "os"
 	#ifdef _WIN32

--- a/language/src/ring_vmos.c
+++ b/language/src/ring_vmos.c
@@ -43,7 +43,9 @@ void ring_vm_os_iswindows ( void *pPointer )
 void ring_vm_os_iswindows64 ( void *pPointer )
 {
 	int lSystem64  ;
-	#ifdef _WIN32
+	#ifdef _WIN64
+		RING_API_RETNUMBER(1);
+	#elif _WIN32
 		HMODULE pModule  ;
 		lSystem64 = 0 ;
 		pModule = GetModuleHandle(TEXT("kernel32"));

--- a/language/src/ring_vmos.c
+++ b/language/src/ring_vmos.c
@@ -20,6 +20,7 @@ void ring_vm_os_loadfunctions ( RingState *pRingState )
 	ring_vm_funcregister("exefilename",ring_vm_os_exefilename);
 	ring_vm_funcregister("chdir",ring_vm_os_chdir);
 	ring_vm_funcregister("exefolder",ring_vm_os_exefolder);
+	ring_vm_funcregister("getarch",ring_vm_os_getarch);
 }
 
 void ring_vm_os_ismsdos ( void *pPointer )
@@ -136,4 +137,19 @@ void ring_vm_os_exefolder ( void *pPointer )
 	char cDirPath[RING_PATHSIZE]  ;
 	ring_exefolder(cDirPath);
 	RING_API_RETSTRING(cDirPath);
+}
+
+void ring_vm_os_getarch( void *pPointer )
+{
+#if (defined(_M_X64) || defined(__x86_64__))
+	RING_API_RETSTRING("x64");
+#elif (defined(_M_IX86) || defined(__i386__) || defined(__i386) || defined(_X86_) || defined(__I86__))
+	RING_API_RETSTRING("x86");
+#elif (defined(__arm64__) || defined(__aarch64__) || defined(_M_ARM64))
+	RING_API_RETSTRING("arm64");
+#elif (defined(__arm__) || defined(_M_ARM) || defined(__aarch32__))
+	RING_API_RETSTRING("arm");
+#else
+	RING_API_RETSTRING("unknow");
+#endif
 }


### PR DESCRIPTION
If ring.exe is 64-bit, then obviously Windows is 64-bit but the code for `isWindows64` was calling `IsWow64Process` which returns false if the process is 64-bit since in this case Wow64 is not enabled for this process (it is native 64-bit).

The fix of this bug uses the define `_WIN64` which exists when building in 64-bit mode (it is defined by both visual studio c++ and mingw64-g++).

We also add a new function `getarch() `which return the build architecture of the Ring executable.
The implementation of this function uses standard define values from across all known compilers to detect the build architecture of the Ring executable.

### GetArch() Function

We can detect the architecture of the Ring executable using the `GetArch()` function

**Syntax:**

GetArch() ---> String containing the name of the architecture of the Ring executable. Possible values are:
   - x86
   - x64
   - arm64
   - arm
   - unknown

**Example:**

```
switch getarch()
case "x86"
        ? "x86 32bit architecture"
case "x64"
        ? "x64 64bit architecture"
case "arm64"
        ? "ARM64 64bit architecture"
case "arm"
        ? "ARM 32bit architecture"
else
        ? "Unknown architecture"
end
```
