### PR TITLE
Fix inconsistency of "unsigned" function between Linux and Windows

### DIFF
--- a/language/src/ring_vmmath.c
+++ b/language/src/ring_vmmath.c
@@ -281,15 +281,15 @@ void ring_vm_math_sqrt ( void *pPointer )
 
 void ring_vm_math_unsigned ( void *pPointer )
 {
-	unsigned long nNum1,nNum2,nNum3  ;
+	RING_UNSIGNEDLONGLONG nNum1,nNum2,nNum3  ;
 	const char *cStr  ;
 	if ( RING_API_PARACOUNT != 3 ) {
 		RING_API_ERROR(RING_API_MISS3PARA);
 		return ;
 	}
 	if ( RING_API_ISNUMBER(1) && RING_API_ISNUMBER(2) && RING_API_ISSTRING(3) ) {
-		nNum1 = (unsigned long) RING_API_GETNUMBER(1) ;
-		nNum2 = (unsigned long) RING_API_GETNUMBER(2) ;
+		nNum1 = (RING_UNSIGNEDLONGLONG) RING_API_GETNUMBER(1) ;
+		nNum2 = (RING_UNSIGNEDLONGLONG) RING_API_GETNUMBER(2) ;
 		cStr = RING_API_GETSTRING(3) ;
 		if ( strcmp(cStr,">>") == 0 ) {
 			nNum3 = nNum1 >> nNum2 ;


### PR DESCRIPTION
The `Unsigned` function was not returning the same results between Linux and Windows. This was caused by the fact that it was using `usigned long` type which doesn't have the same size between Windows and Linux.

The below program display different result between Linux and Windows:
```
a = 4_294_967_295
b = 1
? unsigned (a,b, "+")
```

On Windows it display `0` while on Linux it displays `4294967296`

The fix is easy: use `RING_UNSIGNEDLONGLONG` type instead of `unsigned long`