### PR TITLE
Update SystemCmd()

### DIFF
--- a/language/src/ring_file_extension.c
+++ b/language/src/ring_file_extension.c
@@ -642,6 +642,7 @@ void ring_vm_file_dir ( void *pPointer )
 						}
 					}
 				} while (FindNextFile(hFind, &fdFile))  ;
+				FindClose(hFind);
 				RING_API_RETLIST(pList);
 			}
 			else {

--- a/libraries/stdlib/stdlibcore.ring
+++ b/libraries/stdlib/stdlibcore.ring
@@ -892,23 +892,14 @@ Func chomp(cStr)
 
 Func SystemCmd(cmd)
     System(cmd + "> cmd.txt")
-    cResult = read("cmd.txt")
+    cStr = read("cmd.txt")
     # delete result file after get value
     OSDeleteFile("cmd.txt")
-    cStr = ""
-    pResult = str2list(cResult)
-    len = len(pResult)
-    for line in pResult
-        # if it last item remove newline
-        if pResult[len] = line
-            cStr += substr(line,nl,"")
-            exit
-        ok
-       
-        cStr += line + nl
-    next
-   
-    return cStr
+    if right(cStr,1) = nl
+        cStr = left(cStr,len(cStr)-1)
+    ok
+    
+    return cStr 
 
 /*
 	Get a List of all files in a directory and it's sub directories 

--- a/libraries/stdlib/stdlibcore.ring
+++ b/libraries/stdlib/stdlibcore.ring
@@ -891,9 +891,24 @@ Func chomp(cStr)
 */
 
 Func SystemCmd(cmd)
-	System(cmd + "> cmd.txt")
-	cStr = read("cmd.txt")
-	return cStr
+    System(cmd + "> cmd.txt")
+    cResult = read("cmd.txt")
+    # delete result file after get value
+    OSDeleteFile("cmd.txt")
+    cStr = ""
+    pResult = str2list(cResult)
+    len = len(pResult)
+    for line in pResult
+        # if it last item remove newline
+        if pResult[len] = line
+            cStr += substr(line,nl,"")
+            exit
+        ok
+       
+        cStr += line + nl
+    next
+   
+    return cStr
 
 /*
 	Get a List of all files in a directory and it's sub directories 


### PR DESCRIPTION
remove result file (cmd.txt) after get command value
remove nl from last line of the value for easily use the value 
for example
currentDir = SystemCmd("pwd")
? dir(currentDir)

Before the update we would get the value like this "/root/user/\n"
which would causes an error if we use dir() function or any other function