### PR TITLE
Fix wrong value returned by murmurhash64a/murmurhash64b on Windows

### DIFF
--- a/extensions/ringmurmurhash/ring_murmurhash.h
+++ b/extensions/ringmurmurhash/ring_murmurhash.h
@@ -19,7 +19,7 @@ int is_bool(int tmp)
 
 #define INT2HEX(dest, val) sprintf(dest, "%x", val)
 
-#define LONG2HEX(dest, val) sprintf(dest, "%lx", val)
+#define LONG2HEX(dest, val) sprintf(dest , RING_UNSIGNEDLONGLONG_FORMAT , (RING_UNSIGNEDLONGLONG) val)
 
 #define MH_RETURN_INT(ret_val, ret_type) { \
     if (ret_type) { \


### PR DESCRIPTION
The functions `murmurhash64a` and `murmurhash64b` were returning wrong hex value when third parameter is set to true (meaning return type is hex string). In this case, `sprintf` was used with "%lx" as format although the input is a 64-bit integer value.
The fix is to use RING_UNSIGNEDLONGLONG_FORMAT for `sprintf`.

The program below reproduce the issue on windows: it should display "`b4111e8f925d5920`" but it displays "`925d5920`"
```

load "murmurhashlib.ring"

key = "Ring Language"

s = murmurhash64a (key, 1, 1)

? s
```