### PR TITLE
STEP number fix

### DIFF
--- a/language/include/ring_vm.h
+++ b/language/include/ring_vm.h
@@ -265,7 +265,7 @@
 	/* State */
 	#define RING_STATE_TRYCATCH 1
 	#define RING_STATE_EXIT 2
-	#define RING_STATE_RETURN 3
+	#define RING_STATE_LOOP 3
 	/* Memory */
 	#define RING_MEMORY_GLOBALSCOPE 1
 	/* List as Hash */
@@ -715,9 +715,11 @@
 
 	void ring_vm_savestate ( VM *pVM,List *pList ) ;
 
-	void ring_vm_restorestate ( VM *pVM,List *pList,int nPos,int nFlag ) ;
+	void ring_vm_restorestate ( VM *pVM,List *pList,int nPos,int nType ) ;
 
 	void ring_vm_backstate ( VM *pVM,int x,List *pList ) ;
+
+	void ring_vm_backstate2 ( VM *pVM,int x,List *pList ) ;
 
 	void ring_vm_savestate2 ( VM *pVM,List *pList ) ;
 

--- a/language/src/ring_vm.c
+++ b/language/src/ring_vm.c
@@ -543,10 +543,10 @@ void ring_vm_execute ( VM *pVM )
 			ring_vm_popexitmark(pVM);
 			break ;
 		case ICO_EXIT :
-			ring_vm_exit(pVM,1);
+			ring_vm_exit(pVM,RING_STATE_EXIT);
 			break ;
 		case ICO_LOOP :
-			ring_vm_exit(pVM,2);
+			ring_vm_exit(pVM,RING_STATE_LOOP);
 			break ;
 		/* For Better Performance */
 		case ICO_PUSHP :

--- a/language/src/ring_vmexit.c
+++ b/language/src/ring_vmexit.c
@@ -39,7 +39,7 @@ void ring_vm_exit ( VM *pVM,int nType )
 	int x,y,nStep  ;
 	nStep = 0 ;
 	/* Set Active List */
-	if ( nType == 1 ) {
+	if ( nType == RING_STATE_EXIT ) {
 		pActiveList = pVM->pExitMark ;
 	}
 	else {
@@ -63,7 +63,7 @@ void ring_vm_exit ( VM *pVM,int nType )
 			}
 		}
 		else {
-			if ( nType == 1 ) {
+			if ( nType == RING_STATE_EXIT ) {
 				ring_vm_error(pVM,RING_VM_ERROR_EXITNUMBEROUTSIDERANGE);
 			}
 			else {
@@ -71,22 +71,12 @@ void ring_vm_exit ( VM *pVM,int nType )
 			}
 			return ;
 		}
-		/*
-		**  Call POP Step 
-		**  If we have many nested loops with different step values 
-		**  Then when we exit from more than one loop we must restore the step value too 
-		*/
-		if ( (nType == 1) && (nStep > 1) ) {
-			for ( y = 2 ; y <= nStep ; y++ ) {
-				ring_vm_popstep(pVM);
-			}
-		}
 		pList = ring_list_getlist(pActiveList,x);
 		pVM->nPC = ring_list_getint(pList,1) ;
-		ring_vm_restorestate(pVM,pList,2,RING_STATE_EXIT);
+		ring_vm_restorestate(pVM,pList,2,nType);
 	}
 	else {
-		if ( nType == 1 ) {
+		if ( nType == RING_STATE_EXIT ) {
 			ring_vm_error(pVM,RING_VM_ERROR_EXITWITHOUTLOOP);
 		}
 		else {


### PR DESCRIPTION
Hello,

this is a fix I use inside Ring2E to get STEP number working correctly. This is more a guide, e.g. where to be careful, what to care about (cause I'm still testing, trying to find more issues).
The most important test, as it turned out, is a loop test where loop needs to revert STEP number too, which is missing in official Ring. Hope it helps.

```ring
str = "test"
size = len(str)
for c = 1 to size step 1
? 'c = 1 to size step 1'
? c
	ssize = len(substr(str,2))
	for s = 1 to ssize step 2
		? "s = 1 to ssize step 2"
		? s
		hybrid = new Hybrid(str)
		hsize = len(hybrid)
		for h = 1 to hsize step 3
			? "h = 1 to hsize step 3"
			? h
			loop 2
		next
	next
next

class Hybrid
	data
	func init val 
		data = val

        func operator cOperator,Para
		switch cOperator
			on "len"
				return len(data)
			on "[]"
				return &data[Para]
		off
```
