### PR TITLE
fix for infinite recursions

### DIFF
--- a/language/src/ring_vm.c
+++ b/language/src/ring_vm.c
@@ -1121,6 +1121,7 @@ void ring_vm_callclassinit ( VM *pVM )
 RING_API void ring_vm_showerrormessage ( VM *pVM,const char *cStr )
 {
 	int x,lFunctionCall  ;
+	char *cStr2 ;
 	List *pList  ;
 	const char *cFile  ;
 	const char *cOldFile  ;
@@ -1131,10 +1132,11 @@ RING_API void ring_vm_showerrormessage ( VM *pVM,const char *cStr )
 	/* Print Calling Information */
 	cOldFile = NULL ;
 	lFunctionCall = 0 ;
+	cStr = "" ;
 	for ( x = ring_list_getsize(pVM->pFuncCallList) ; x >= 1 ; x-- ) {
 		pList = ring_list_getlist(pVM->pFuncCallList,x);
 		/*
-		**  If we have ICO_LoadFunc but not ICO_CALL then we need to pass 
+		**  If we have ICO_LOADFUNC but not ICO_CALL then we need to pass 
 		**  ICO_LOADFUNC is executed, but still ICO_CALL is not executed! 
 		*/
 		if ( ring_list_getsize(pList) < RING_FUNCCL_CALLERPC ) {
@@ -1142,6 +1144,10 @@ RING_API void ring_vm_showerrormessage ( VM *pVM,const char *cStr )
 			continue ;
 		}
 		if ( ring_list_getint(pList,RING_FUNCCL_TYPE) == RING_FUNCTYPE_SCRIPT ) {
+			cStr2 = ring_list_getstring(pList,RING_FUNCCL_NAME) ;
+			if ( strcmp(cStr,cStr2) == 0 ) {
+				break ;
+			}
 			/*
 			**  Prepare Message 
 			**  In 
@@ -1155,7 +1161,7 @@ RING_API void ring_vm_showerrormessage ( VM *pVM,const char *cStr )
 				printf( "function " ) ;
 			}
 			/* Function Name */
-			printf( "%s",ring_list_getstring(pList,RING_FUNCCL_NAME) ) ;
+			printf( "%s",cStr2 ) ;
 			/* Adding () */
 			printf( "() in file " ) ;
 			/* File Name */
@@ -1178,6 +1184,7 @@ RING_API void ring_vm_showerrormessage ( VM *pVM,const char *cStr )
 			printf( "In %s() ",ring_list_getstring(pList,RING_FUNCCL_NAME) ) ;
 		}
 		lFunctionCall = 1 ;
+		cStr = cStr2 ;
 	}
 	if ( lFunctionCall ) {
 		printf( "in file %s ",ring_list_getstring(pVM->pRingState->pRingFilesList,1) ) ;

--- a/language/src/ring_vmvars.c
+++ b/language/src/ring_vmvars.c
@@ -9,6 +9,10 @@
 
 void ring_vm_newscope ( VM *pVM )
 {
+	if ( ring_list_getsize(pVM->pMem) == RING_VM_STACK_SIZE ) {
+		ring_vm_error(pVM,RING_VM_ERROR_STACKOVERFLOW);
+		exit(0);
+	}
 	pVM->pActiveMem = ring_list_newlist_gc(pVM->pRingState,pVM->pMem);
 	/* Save Local Scope Information */
 	pVM->nScopeID++ ;


### PR DESCRIPTION
Hello,

here is a pull request as you suggested. Please note, I also changed showerrormessage function, otherwise long list of (empty in content) messages are printed to the console. This can also be fixed by simply putting

`		if ( x == RING_VM_STACK_SIZE ) {
			break ;
		}
`

at the end of the loop. Which one is correct, you decide.

Back to newscope function: I'm not sure, but maybe we should use RING_VM_STACKSIZE multiplied by 4 here. If I remember correctly, stack size is usually 4096 bytes on 32 bit systems, address takes 4 bytes, therefore 1024 (return) addresses can fit onto stack (thinking about Ring2C here). However, this has to be documented then. If someone increases RING_VM_STACKSIZE to 1024, then above does not apply I think.