### PR TITLE
to be on the safe side

### DIFF
--- a/extensions/ringlibuv/libuv.cf
+++ b/extensions/ringlibuv/libuv.cf
@@ -101,8 +101,8 @@ void uv_timer_callback(uv_timer_t *handle)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,handle,"uv_timer_t");
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,handle,"uv_timer_t");
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 
@@ -118,8 +118,8 @@ void uv_prepare_callback(uv_prepare_t *handle)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,handle,"uv_prepare_t");
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,handle,"uv_prepare_t");
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -134,8 +134,8 @@ void uv_check_callback(uv_check_t *handle)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,handle,"uv_check_t");
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,handle,"uv_check_t");
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -150,8 +150,8 @@ void uv_idle_callback(uv_idle_t *obj)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,obj,"uv_idle_t");
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,obj,"uv_idle_t");
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 } 
@@ -166,10 +166,10 @@ void uv_poll_callback(uv_poll_t *obj,int status,int events)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,obj,"uv_poll_t");
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,status);
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,events);
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,obj,"uv_poll_t");
+		ring_list_adddouble_gc(NULL,pPara,status);
+		ring_list_adddouble_gc(NULL,pPara,events);
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 } 
@@ -184,9 +184,9 @@ void uv_signal_callback(uv_signal_t *obj,int signum)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,obj,"uv_signal_t");
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,signum);
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,obj,"uv_signal_t");
+		ring_list_adddouble_gc(NULL,pPara,signum);
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 } 
@@ -201,9 +201,9 @@ void uv_shutdown_callback(uv_shutdown_t *obj,int status)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,obj,"uv_shutdown_t");
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,status);
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,obj,"uv_shutdown_t");
+		ring_list_adddouble_gc(NULL,pPara,status);
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 	uv_close((uv_handle_t*) obj->handle, (uv_close_cb) free); 
@@ -219,9 +219,9 @@ void uv_connection_callback(uv_stream_t *obj,int status)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,obj,"uv_stream_t");
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,status);
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,obj,"uv_stream_t");
+		ring_list_adddouble_gc(NULL,pPara,status);
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 } 
@@ -236,9 +236,9 @@ void uv_write_callback(uv_write_t *obj,int status)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,obj,"uv_write_t");
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,status);
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,obj,"uv_write_t");
+		ring_list_adddouble_gc(NULL,pPara,status);
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 } 
@@ -253,9 +253,9 @@ void uv_connect_callback(uv_connect_t *req, int status)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,req,"uv_connect_t");
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,status);
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,req,"uv_connect_t");
+		ring_list_adddouble_gc(NULL,pPara,status);
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -270,11 +270,11 @@ void uv_fs_event_callback(uv_fs_event_t *req, const char* filename, int events, 
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,req,"uv_fs_event_t");
-		ring_list_addstring_gc(pVMLibUV->pRingState,pPara,filename);
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,events);
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,status);
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,req,"uv_fs_event_t");
+		ring_list_addstring_gc(NULL,pPara,filename);
+		ring_list_adddouble_gc(NULL,pPara,events);
+		ring_list_adddouble_gc(NULL,pPara,status);
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -289,8 +289,8 @@ void uv_fs_callback(uv_fs_t *req)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,req,"uv_fs_t");
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,req,"uv_fs_t");
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -315,8 +315,8 @@ void uv_thread_callback(void *obj)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,obj,"void");
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,obj,"void");
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcodefromthread(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -331,9 +331,9 @@ void uv_walk_callback(uv_handle_t *handle, void *arg)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,handle,"uv_handle_t");
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,arg,"void");
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,handle,"uv_handle_t");
+		ring_list_addcpointer_gc(NULL,pPara,arg,"void");
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -348,8 +348,8 @@ void uv_close_callback(uv_handle_t *handle)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,handle,"uv_handle_t");
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,handle,"uv_handle_t");
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -364,8 +364,8 @@ void uv_async_callback(uv_async_t *handle)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,handle,"uv_async_t");
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,handle,"uv_async_t");
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -380,10 +380,10 @@ void uv_alloc_callback(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,handle,"uv_handle_t");
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,suggested_size);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,buf,"uv_buf_t");
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,handle,"uv_handle_t");
+		ring_list_adddouble_gc(NULL,pPara,suggested_size);
+		ring_list_addcpointer_gc(NULL,pPara,buf,"uv_buf_t");
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -398,10 +398,10 @@ void uv_read_callback(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,stream,"uv_stream_t");
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,nread);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,(uv_buf_t *) buf,"uv_buf_t");
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,stream,"uv_stream_t");
+		ring_list_adddouble_gc(NULL,pPara,nread);
+		ring_list_addcpointer_gc(NULL,pPara,(uv_buf_t *) buf,"uv_buf_t");
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -416,9 +416,9 @@ void uv_udp_send_callback(uv_udp_send_t* req, int status)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,req,"uv_udp_send_t");
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,status);
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,req,"uv_udp_send_t");
+		ring_list_adddouble_gc(NULL,pPara,status);
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -433,12 +433,12 @@ void uv_udp_recv_callback(uv_udp_t* handle, ssize_t nread, const uv_buf_t* buf, 
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,handle,"uv_udp_t");
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,nread);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,(uv_buf_t *) buf,"uv_buf_t");
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,(struct sockaddr *) addr,"sockaddr");
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,flags);
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,handle,"uv_udp_t");
+		ring_list_adddouble_gc(NULL,pPara,nread);
+		ring_list_addcpointer_gc(NULL,pPara,(uv_buf_t *) buf,"uv_buf_t");
+		ring_list_addcpointer_gc(NULL,pPara,(struct sockaddr *) addr,"sockaddr");
+		ring_list_adddouble_gc(NULL,pPara,flags);
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -453,11 +453,11 @@ void uv_fs_poll_callback(uv_fs_poll_t* handle, int status, const uv_stat_t* prev
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,handle,"uv_fs_poll_t");
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,status);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,(uv_stat_t *) prev,"uv_stat_t");
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,(uv_stat_t *) curr,"uv_stat_t");
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,handle,"uv_fs_poll_t");
+		ring_list_adddouble_gc(NULL,pPara,status);
+		ring_list_addcpointer_gc(NULL,pPara,(uv_stat_t *) prev,"uv_stat_t");
+		ring_list_addcpointer_gc(NULL,pPara,(uv_stat_t *) curr,"uv_stat_t");
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -472,8 +472,8 @@ void uv_work_callback(uv_work_t* req)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,req,"uv_work_t");
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,req,"uv_work_t");
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -488,9 +488,9 @@ void uv_after_work_callback(uv_work_t* req, int status)
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,req,"uv_work_t");
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,status);
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,req,"uv_work_t");
+		ring_list_adddouble_gc(NULL,pPara,status);
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -505,10 +505,10 @@ void uv_getaddrinfo_callback(uv_getaddrinfo_t* req, int status, struct addrinfo*
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,req,"uv_getaddrinfo_t");
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,status);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,res,"addrinfo");
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,req,"uv_getaddrinfo_t");
+		ring_list_adddouble_gc(NULL,pPara,status);
+		ring_list_addcpointer_gc(NULL,pPara,res,"addrinfo");
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -523,11 +523,11 @@ void uv_getnameinfo_callback(uv_getnameinfo_t* req, int status, const char* host
 	pList = ring_list_getlist(aCallBack,x) ;
 	// Add the Event Parameters
 		pPara = ring_list_getlist(pList,RINGLIBUV_EVENTPARA);
-		ring_list_deleteallitems_gc(pVMLibUV->pRingState,pPara);
-		ring_list_addcpointer_gc(pVMLibUV->pRingState,pPara,req,"uv_getnameinfo_t");
-		ring_list_adddouble_gc(pVMLibUV->pRingState,pPara,status);
-		ring_list_addstring_gc(pVMLibUV->pRingState,pPara,hostname);
-		ring_list_addstring_gc(pVMLibUV->pRingState,pPara,service);
+		ring_list_deleteallitems_gc(NULL,pPara);
+		ring_list_addcpointer_gc(NULL,pPara,req,"uv_getnameinfo_t");
+		ring_list_adddouble_gc(NULL,pPara,status);
+		ring_list_addstring_gc(NULL,pPara,hostname);
+		ring_list_addstring_gc(NULL,pPara,service);
 	ring_vm_mutexunlock(pVMLibUV);
 	ring_vm_runcode(pVMLibUV,ring_list_getstring(pList,3));
 }
@@ -569,7 +569,7 @@ RING_FUNC(ring_uv_deletecallbacks)
 		pList = ring_list_getlist(aCallBack,x) ;
 		if (  ring_list_getpointer(pList,1) == pObject  )
 		{
-			ring_list_deleteitem_gc(pVMLibUV->pRingState,aCallBack,x);
+			ring_list_deleteitem_gc(NULL,aCallBack,x);
 			break ;
 		}
 	}
@@ -580,7 +580,7 @@ RING_FUNC(ring_uv_deletecallbacks)
 RING_FUNC(ring_uv_deleteallcallbacks)
 {
 	ring_vm_mutexlock(pVMLibUV);
-	ring_list_deleteallitems_gc(pVMLibUV->pRingState,aCallBack) ;
+	ring_list_deleteallitems_gc(NULL,aCallBack) ;
 	ring_vm_mutexunlock(pVMLibUV);
 }
 
@@ -604,7 +604,7 @@ RING_FUNC(ring_uv_deletecallbacksafter)
 	nEnd = (int) RING_API_GETNUMBER(1);
 	ring_vm_mutexlock(pVMLibUV);
 	for (x = nStart ; x > nEnd  ; x-- ) {
-		ring_list_deleteitem_gc(pVMLibUV->pRingState,aCallBack,x);
+		ring_list_deleteitem_gc(NULL,aCallBack,x);
 	}
 	ring_vm_mutexunlock(pVMLibUV);
 }
@@ -625,15 +625,15 @@ RING_FUNC(ring_uv_callback)
 	ring_vm_mutexlock(pVMLibUV);
 	if ( aCallBack == NULL ) 
 	{
-		aCallBack = ring_list_new_gc(pVMLibUV->pRingState,0);
+		aCallBack = ring_list_new_gc(NULL,0);
 	}
 	cCallBackType = RING_API_GETSTRING(2) ;
-	pList = ring_list_newlist_gc(pVMLibUV->pRingState,aCallBack);
-	ring_list_addpointer_gc(pVMLibUV->pRingState,pList,RING_API_GETCPOINTER(1,"void"));
-	ring_list_addstring_gc(pVMLibUV->pRingState,pList,cCallBackType);
-	ring_list_addstring_gc(pVMLibUV->pRingState,pList,RING_API_GETSTRING(3));
+	pList = ring_list_newlist_gc(NULL,aCallBack);
+	ring_list_addpointer_gc(NULL,pList,RING_API_GETCPOINTER(1,"void"));
+	ring_list_addstring_gc(NULL,pList,cCallBackType);
+	ring_list_addstring_gc(NULL,pList,RING_API_GETSTRING(3));
 	// Add List for the Event Parameters
-		ring_list_newlist_gc(pVMLibUV->pRingState,pList);	
+		ring_list_newlist_gc(NULL,pList);	
 	ring_vm_mutexunlock(pVMLibUV);
 	if (strcmp(cCallBackType,"timer") == 0)
 	{


### PR DESCRIPTION
Hello Mahmoud,

it seems there is some fix from Ring2A I could bring here. Fixing application crash when main thread and worker thread are in conflict. If you remember, the colors list initialization in wavingcubes sample cause app crash if it is done after the creation of the thread. It seems that main thread and worker thread are trying to write into GC pool memory at the same time. To be on the safe side, I fixed it by completely removing memory pool usage at ringlibuv. Please review, see if can be done better (differently).

There is also conflict in a worker thread code. At the end of the execution, there is a code which is bringing back items to the memory pool of the main thread causing write operation on both sides. This is fixed in Ring2A, but I can't bring it here because my code is significantly different.

