### PR TITLE
better ringCMD.bat 

### DIFF
--- a/RingCMD.bat
+++ b/RingCMD.bat
@@ -1,0 +1,5 @@
+@echo off
+set path=%~dp0\bin;%path%
+cls
+@echo on
+cmd.exe /K ring -h


### PR DESCRIPTION
Hi,
I fixed the `RingCmd.bat` to work without `cd` to the script folder (it use `%cd%`) and also display the ring help message.
Thanks, 
Matan h