### PR TITLE
fixed zero case

### DIFF
--- a/language/src/ring_vmexpr.c
+++ b/language/src/ring_vmexpr.c
@@ -304,7 +304,13 @@ void ring_vm_equal ( VM *pVM )
 		else if ( RING_VM_STACK_ISNUMBER ) {
 			nNum1 = RING_VM_STACK_READN ;
 			if ( ring_vm_stringtonum(pVM,ring_string_get(cStr1)) == nNum1 ) {
-				RING_VM_STACK_TRUE ;
+				/* Check whether zero is result of non decimal or hexadecimal value */
+				if( nNum1 == 0 && ring_string_get(cStr1)[0] != '\0' && sscanf(ring_string_get(cStr1),"%lf",&nNum2) != 1 ) {
+					RING_VM_STACK_FALSE ;
+				}
+				else {
+					RING_VM_STACK_TRUE ;
+				}
 			}
 			else {
 				RING_VM_STACK_FALSE ;
@@ -329,7 +335,13 @@ void ring_vm_equal ( VM *pVM )
 		}
 		else if ( RING_VM_STACK_ISSTRING ) {
 			if ( ring_vm_stringtonum(pVM,RING_VM_STACK_READC) == nNum1 ) {
-				RING_VM_STACK_TRUE ;
+				/* Check whether zero is result of non decimal or hexadecimal value */
+				if( nNum1 == 0 && RING_VM_STACK_READC[0] != '\0' && sscanf(RING_VM_STACK_READC,"%lf",&nNum2) != 1 ) {
+					RING_VM_STACK_FALSE ;
+				}
+				else {
+					RING_VM_STACK_TRUE ;
+				}
 			}
 			else {
 				RING_VM_STACK_FALSE ;
@@ -565,7 +577,13 @@ void ring_vm_notequal ( VM *pVM )
 			nNum1 = ring_vm_stringtonum(pVM,ring_string_get(cStr1)) ;
 			/* Compare */
 			if ( nNum1 == nNum2 ) {
-				RING_VM_STACK_FALSE ;
+				/* Check whether zero is result of non decimal or hexadecimal value */
+				if( nNum1 == 0 && ring_string_get(cStr1)[0] != '\0' && sscanf(ring_string_get(cStr1),"%lf",&nNum2) != 1 ) {
+					RING_VM_STACK_TRUE ;
+				}
+				else {
+					RING_VM_STACK_FALSE ;
+				}
 			}
 			else {
 				RING_VM_STACK_TRUE ;
@@ -593,7 +611,13 @@ void ring_vm_notequal ( VM *pVM )
 			cStr2 = RING_VM_STACK_GETSTRINGRAW ;
 			/* Compare */
 			if ( ring_vm_stringtonum(pVM,ring_string_get(cStr2)) == nNum1 ) {
-				RING_VM_STACK_FALSE ;
+				/* Check whether zero is result of non decimal or hexadecimal value */
+				if( nNum1 == 0 && ring_string_get(cStr2)[0] != '\0' && sscanf(ring_string_get(cStr2),"%lf",&nNum2) != 1 ) {
+					RING_VM_STACK_TRUE ;
+				}
+				else {
+					RING_VM_STACK_FALSE ;
+				}
 			}
 			else {
 				RING_VM_STACK_TRUE ;


### PR DESCRIPTION
Hello Mahmoud,

here is the "zero case" fix. Please note: greater-equal, less-equal, etc. is not covered, check if it is necessary. Issue is complex and it should be revised for Ring 1.16 I think. 