### PR TITLE
hotfix4

### DIFF
--- a/language/src/ring_objfile.c
+++ b/language/src/ring_objfile.c
@@ -727,7 +727,7 @@ int ring_objfile_writelistcode ( List *pList,FILE *fCode,int nList,int lSeparate
 {
 	List *pList2  ;
 	int x,x2,x3,nMax  ;
-	char cList[7]  ;
+	char cList[20]  ;
 	char *cString  ;
 	char cFileName[400]  ;
 	sprintf( cList , "pList%d" , nList+1 ) ;


### PR DESCRIPTION
Hello,

I think gcc compiler message on Linux is enough to describe what was wrong:

In file included from /usr/include/stdio.h:867,
                 from /home/developer/ring/language/src/../include/ring.h:6,
                 from ring_objfile.c:5:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 7 and 17 bytes into a destination of size 7
   36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   37 |       __bos (__s), __fmt, __va_arg_pack ());
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Good and a bad news: I found reason why and where is VM failing outside of the gdb. Bad news is: after I switched back to original official Ring VM code, meaning VM on Windows have speed advantage. Will see what will happen while compiling on Mac.