### PR TITLE
Update Sockets: extend constants from c instead of define it hard coded

### DIFF
--- a/extensions/ringsockets/buildclang.sh
+++ b/extensions/ringsockets/buildclang.sh
@@ -1,3 +1,3 @@
-clang -c -fpic -O2 ext/sockets.c -I $PWD/../../language/include
-clang -dynamiclib -o $PWD/../../lib/libring_sockets.dylib sockets.o  -L $PWD/../../lib -lring
-
+clang -c -fpic -O2 ext/*.c -I $PWD/ext/ -I $PWD/../../language/include
+clang -dynamiclib -o $PWD/../../lib/libring_sockets.dylib *.o  -L $PWD/../../lib -lring
+rm *.o

--- a/extensions/ringsockets/buildgcc.sh
+++ b/extensions/ringsockets/buildgcc.sh
@@ -1,2 +1,3 @@
-gcc -c -fpic -O2 ext/sockets.c -o sockets.o -I ../../language/include/
-gcc -shared -o $PWD/../../lib/libring_sockets.so sockets.o -L ../../lib/ -lring
+gcc -c -fpic -O2 ext/*.c -I ext/ -I ../../language/include/
+gcc -shared -o $PWD/../../lib/libring_sockets.so *.o -L ../../lib/ -lring
+rm *.o

--- a/extensions/ringsockets/buildvc.bat
+++ b/extensions/ringsockets/buildvc.bat
@@ -1,5 +1,5 @@
 cls
 call ../../language/src/locatevc.bat
-cl /c /DEBUG ext\sockets.c -I"..\..\language\include"
-link /DEBUG sockets.obj  ..\..\lib\ring.lib /DLL /OUT:..\..\bin\ring_sockets.dll /SUBSYSTEM:CONSOLE,"5.01"
-del sockets.obj
+cl /c /DEBUG ext\*.c -I"..\..\language\include" -I"ext\"
+link /DEBUG *.obj  ..\..\lib\ring.lib /DLL /OUT:..\..\bin\ring_sockets.dll /SUBSYSTEM:CONSOLE,"5.01"
+del *.obj

--- a/extensions/ringsockets/docs/docs.txt
+++ b/extensions/ringsockets/docs/docs.txt
@@ -36,16 +36,13 @@ Protocol Families :
                 - PF_UNIX
                 - PF_INET
                 - PF_INET6
-                - PF_INET6
 
 
 Address Families :   
                 - AF_INET       >>  mean use IPV4
                 - AF_INET6      >>  ........ IPV6
                 - AF_UNSPEC
-                - AF_LOCAL
                 - AF_UNIX
-                - PF_FILE
 
 
 Connection type :
@@ -59,7 +56,6 @@ Levels :
                 - IPPROTO_IP
                 - IPPROTO_TCP
                 - IPPROTO_UDP
-                - SOL_SOCKET
                 - SOL_SOCKET
 
 Option names :

--- a/extensions/ringsockets/ext/constants.c
+++ b/extensions/ringsockets/ext/constants.c
@@ -6,19 +6,9 @@ void ring_vm_socket_constant_pf_unspec(void *pPointer)
     RING_API_RETNUMBER(PF_UNSPEC);
 }
 
-void ring_vm_socket_constant_pf_local(void *pPointer)
-{
-    RING_API_RETNUMBER(PF_LOCAL);
-}
-
 void ring_vm_socket_constant_pf_unix(void *pPointer)
 {
     RING_API_RETNUMBER(PF_UNIX);
-}
-
-void ring_vm_socket_constant_pf_file(void *pPointer)
-{
-    RING_API_RETNUMBER(PF_FILE);
 }
 
 void ring_vm_socket_constant_pf_inet(void *pPointer)
@@ -34,11 +24,6 @@ void ring_vm_socket_constant_pf_inet6(void *pPointer)
 void ring_vm_socket_constant_af_unspec(void *pPointer)
 {
     RING_API_RETNUMBER(AF_UNSPEC);
-}
-
-void ring_vm_socket_constant_af_local(void *pPointer)
-{
-    RING_API_RETNUMBER(AF_LOCAL);
 }
 
 void ring_vm_socket_constant_af_unix(void *pPointer)

--- a/extensions/ringsockets/ext/constants.c
+++ b/extensions/ringsockets/ext/constants.c
@@ -1,0 +1,267 @@
+
+#include "constants.h"
+
+void ring_vm_socket_constant_pf_unspec(void *pPointer)
+{
+    RING_API_RETNUMBER(PF_UNSPEC);
+}
+
+void ring_vm_socket_constant_pf_local(void *pPointer)
+{
+    RING_API_RETNUMBER(PF_LOCAL);
+}
+
+void ring_vm_socket_constant_pf_unix(void *pPointer)
+{
+    RING_API_RETNUMBER(PF_UNIX);
+}
+
+void ring_vm_socket_constant_pf_file(void *pPointer)
+{
+    RING_API_RETNUMBER(PF_FILE);
+}
+
+void ring_vm_socket_constant_pf_inet(void *pPointer)
+{
+    RING_API_RETNUMBER(PF_INET);
+}
+
+void ring_vm_socket_constant_pf_inet6(void *pPointer)
+{
+    RING_API_RETNUMBER(PF_INET6);
+}
+
+void ring_vm_socket_constant_af_unspec(void *pPointer)
+{
+    RING_API_RETNUMBER(AF_UNSPEC);
+}
+
+void ring_vm_socket_constant_af_local(void *pPointer)
+{
+    RING_API_RETNUMBER(AF_LOCAL);
+}
+
+void ring_vm_socket_constant_af_unix(void *pPointer)
+{
+    RING_API_RETNUMBER(AF_UNIX);
+}
+
+void ring_vm_socket_constant_af_inet(void *pPointer)
+{
+    RING_API_RETNUMBER(AF_INET);
+}
+
+void ring_vm_socket_constant_af_inet6(void *pPointer)
+{
+    RING_API_RETNUMBER(AF_INET6);
+}
+
+void ring_vm_socket_constant_sock_stream(void *pPointer)
+{
+    RING_API_RETNUMBER(SOCK_STREAM);
+}
+
+void ring_vm_socket_constant_sock_dgram(void *pPointer)
+{
+    RING_API_RETNUMBER(SOCK_DGRAM);
+}
+
+void ring_vm_socket_constant_sock_raw(void *pPointer)
+{
+    RING_API_RETNUMBER(SOCK_RAW);
+}
+
+void ring_vm_socket_constant_sock_rdm(void *pPointer)
+{
+    RING_API_RETNUMBER(SOCK_RDM);
+}
+
+void ring_vm_socket_constant_sock_seqpacket(void *pPointer)
+{
+    RING_API_RETNUMBER(SOCK_SEQPACKET);
+}
+
+void ring_vm_socket_constant_ipproto_ip(void *pPointer)
+{
+    RING_API_RETNUMBER(IPPROTO_IP);
+}
+
+void ring_vm_socket_constant_ipproto_tcp(void *pPointer)
+{
+    RING_API_RETNUMBER(IPPROTO_TCP);
+}
+
+void ring_vm_socket_constant_ipproto_udp(void *pPointer)
+{
+    RING_API_RETNUMBER(IPPROTO_UDP);
+}
+
+void ring_vm_socket_constant_sol_socket(void *pPointer)
+{
+    RING_API_RETNUMBER(SOL_SOCKET);
+}
+
+void ring_vm_socket_constant_so_debug(void *pPointer)
+{
+    RING_API_RETNUMBER(SO_DEBUG);
+}
+
+void ring_vm_socket_constant_ip_add_membership(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_ADD_MEMBERSHIP);
+}
+
+void ring_vm_socket_constant_ip_add_source_membership(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_ADD_SOURCE_MEMBERSHIP);
+}
+
+void ring_vm_socket_constant_ip_block_source(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_BLOCK_SOURCE);
+}
+
+void ring_vm_socket_constant_ip_drop_membership(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_DROP_MEMBERSHIP);
+}
+
+void ring_vm_socket_constant_ip_drop_source_membership(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_DROP_SOURCE_MEMBERSHIP);
+}
+
+void ring_vm_socket_constant_ip_hdrincl(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_HDRINCL);
+}
+
+void ring_vm_socket_constant_ip_mtu(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_MTU);
+}
+
+void ring_vm_socket_constant_ip_mtu_discover(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_MTU_DISCOVER);
+}
+
+void ring_vm_socket_constant_ip_multicast_loop(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_MULTICAST_LOOP);
+}
+
+void ring_vm_socket_constant_ip_multicast_ttl(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_MULTICAST_TTL);
+}
+
+void ring_vm_socket_constant_ip_options(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_OPTIONS);
+}
+
+void ring_vm_socket_constant_ip_pktinfo(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_PKTINFO);
+}
+
+void ring_vm_socket_constant_ip_recvtos(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_RECVTOS);
+}
+
+void ring_vm_socket_constant_ip_recvttl(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_RECVTTL);
+}
+
+void ring_vm_socket_constant_ip_tos(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_TOS);
+}
+
+void ring_vm_socket_constant_ip_ttl(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_TTL);
+}
+
+void ring_vm_socket_constant_ip_unblock_source(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_UNBLOCK_SOURCE);
+}
+
+void ring_vm_socket_constant_ip_unicast_if(void *pPointer)
+{
+    RING_API_RETNUMBER(IP_UNICAST_IF);
+}
+
+void ring_vm_socket_constant_so_acceptconn(void *pPointer)
+{
+    RING_API_RETNUMBER(SO_ACCEPTCONN);
+}
+
+void ring_vm_socket_constant_so_broadcast(void *pPointer)
+{
+    RING_API_RETNUMBER(SO_BROADCAST);
+}
+
+void ring_vm_socket_constant_so_dontroute(void *pPointer)
+{
+    RING_API_RETNUMBER(SO_DONTROUTE);
+}
+
+void ring_vm_socket_constant_so_error(void *pPointer)
+{
+    RING_API_RETNUMBER(SO_ERROR);
+}
+
+void ring_vm_socket_constant_so_keepalive(void *pPointer)
+{
+    RING_API_RETNUMBER(SO_KEEPALIVE);
+}
+
+void ring_vm_socket_constant_so_linger(void *pPointer)
+{
+    RING_API_RETNUMBER(SO_LINGER);
+}
+
+void ring_vm_socket_constant_so_oobinline(void *pPointer)
+{
+    RING_API_RETNUMBER(SO_OOBINLINE);
+}
+
+void ring_vm_socket_constant_so_rcvbuf(void *pPointer)
+{
+    RING_API_RETNUMBER(SO_RCVBUF);
+}
+
+void ring_vm_socket_constant_so_reuseaddr(void *pPointer)
+{
+    RING_API_RETNUMBER(SO_REUSEADDR);
+}
+
+void ring_vm_socket_constant_so_sndbuf(void *pPointer)
+{
+    RING_API_RETNUMBER(SO_SNDBUF);
+}
+
+void ring_vm_socket_constant_so_type(void *pPointer)
+{
+    RING_API_RETNUMBER(SO_TYPE);
+}
+
+void ring_vm_socket_constant_so_rcvlowat(void *pPointer)
+{
+    RING_API_RETNUMBER(SO_RCVLOWAT);
+}
+
+void ring_vm_socket_constant_so_sndlowat(void *pPointer)
+{
+    RING_API_RETNUMBER(SO_SNDLOWAT);
+}
+
+void ring_vm_socket_constant_so_rcvtimeo(void *pPointer)
+{
+    RING_API_RETNUMBER(SO_RCVTIMEO);
+}

--- a/extensions/ringsockets/ext/constants.h
+++ b/extensions/ringsockets/ext/constants.h
@@ -6,15 +6,12 @@
 
 /* Protocol Families */
 void ring_vm_socket_constant_pf_unspec(void *pPointer);
-void ring_vm_socket_constant_pf_local(void *pPointer);
 void ring_vm_socket_constant_pf_unix(void *pPointer);
-void ring_vm_socket_constant_pf_file(void *pPointer);
 void ring_vm_socket_constant_pf_inet(void *pPointer);
 void ring_vm_socket_constant_pf_inet6(void *pPointer);
 
 /* Address Families */
 void ring_vm_socket_constant_af_unspec(void *pPointer);
-void ring_vm_socket_constant_af_local(void *pPointer);
 void ring_vm_socket_constant_af_unix(void *pPointer);
 void ring_vm_socket_constant_af_inet(void *pPointer);
 void ring_vm_socket_constant_af_inet6(void *pPointer);

--- a/extensions/ringsockets/ext/constants.h
+++ b/extensions/ringsockets/ext/constants.h
@@ -1,0 +1,70 @@
+#ifndef HAVE_RING_SOCKET_CONSTANTS
+#define HAVE_RING_SOCKET_CONSTANTS
+
+#include "sockets.h"
+
+
+/* Protocol Families */
+void ring_vm_socket_constant_pf_unspec(void *pPointer);
+void ring_vm_socket_constant_pf_local(void *pPointer);
+void ring_vm_socket_constant_pf_unix(void *pPointer);
+void ring_vm_socket_constant_pf_file(void *pPointer);
+void ring_vm_socket_constant_pf_inet(void *pPointer);
+void ring_vm_socket_constant_pf_inet6(void *pPointer);
+
+/* Address Families */
+void ring_vm_socket_constant_af_unspec(void *pPointer);
+void ring_vm_socket_constant_af_local(void *pPointer);
+void ring_vm_socket_constant_af_unix(void *pPointer);
+void ring_vm_socket_constant_af_inet(void *pPointer);
+void ring_vm_socket_constant_af_inet6(void *pPointer);
+
+/* Connection Types */
+void ring_vm_socket_constant_sock_stream(void *pPointer);
+void ring_vm_socket_constant_sock_dgram(void *pPointer);
+void ring_vm_socket_constant_sock_raw(void *pPointer);
+void ring_vm_socket_constant_sock_rdm(void *pPointer);
+void ring_vm_socket_constant_sock_seqpacket(void *pPointer);
+
+/* Levels */
+void ring_vm_socket_constant_ipproto_ip(void *pPointer);
+void ring_vm_socket_constant_ipproto_tcp(void *pPointer);
+void ring_vm_socket_constant_ipproto_udp(void *pPointer);
+void ring_vm_socket_constant_sol_socket(void *pPointer);
+
+/* Option names */
+void ring_vm_socket_constant_so_debug(void *pPointer);
+void ring_vm_socket_constant_ip_add_membership(void *pPointer);
+void ring_vm_socket_constant_ip_add_source_membership(void *pPointer);
+void ring_vm_socket_constant_ip_block_source(void *pPointer);
+void ring_vm_socket_constant_ip_drop_membership(void *pPointer);
+void ring_vm_socket_constant_ip_drop_source_membership(void *pPointer);
+void ring_vm_socket_constant_ip_hdrincl(void *pPointer);
+void ring_vm_socket_constant_ip_mtu(void *pPointer);
+void ring_vm_socket_constant_ip_mtu_discover(void *pPointer);
+void ring_vm_socket_constant_ip_multicast_loop(void *pPointer);
+void ring_vm_socket_constant_ip_multicast_ttl(void *pPointer);
+void ring_vm_socket_constant_ip_options(void *pPointer);
+void ring_vm_socket_constant_ip_pktinfo(void *pPointer);
+void ring_vm_socket_constant_ip_recvtos(void *pPointer);
+void ring_vm_socket_constant_ip_recvttl(void *pPointer);
+void ring_vm_socket_constant_ip_tos(void *pPointer);
+void ring_vm_socket_constant_ip_ttl(void *pPointer);
+void ring_vm_socket_constant_ip_unblock_source(void *pPointer);
+void ring_vm_socket_constant_ip_unicast_if(void *pPointer);
+void ring_vm_socket_constant_so_acceptconn(void *pPointer);
+void ring_vm_socket_constant_so_broadcast(void *pPointer);
+void ring_vm_socket_constant_so_dontroute(void *pPointer);
+void ring_vm_socket_constant_so_error(void *pPointer);
+void ring_vm_socket_constant_so_keepalive(void *pPointer);
+void ring_vm_socket_constant_so_linger(void *pPointer);
+void ring_vm_socket_constant_so_oobinline(void *pPointer);
+void ring_vm_socket_constant_so_rcvbuf(void *pPointer);
+void ring_vm_socket_constant_so_reuseaddr(void *pPointer);
+void ring_vm_socket_constant_so_sndbuf(void *pPointer);
+void ring_vm_socket_constant_so_type(void *pPointer);
+void ring_vm_socket_constant_so_rcvlowat(void *pPointer);
+void ring_vm_socket_constant_so_sndlowat(void *pPointer);
+void ring_vm_socket_constant_so_rcvtimeo(void *pPointer);
+
+#endif

--- a/extensions/ringsockets/ext/sockets.c
+++ b/extensions/ringsockets/ext/sockets.c
@@ -6,7 +6,6 @@
 
 #define WIN32_LEAN_AND_MEAN
 
-#include "ring.h"
 #include "sockets.h"
 
 
@@ -789,6 +788,67 @@ RING_API void ringlib_init(RingState *pRingState) {
     ring_vm_funcregister("htons",ring_vm_socket_htons);
     ring_vm_funcregister("inet_addr",ring_vm_socket_inet_addr);
     ring_vm_funcregister("inet_ntoa",ring_vm_socket_inet_ntoa); 
+
+
+    /* Constants */
+
+    ring_vm_funcregister("get_pf_unspec",ring_vm_socket_constant_pf_unspec);
+    ring_vm_funcregister("get_pf_local",ring_vm_socket_constant_pf_local);
+    ring_vm_funcregister("get_pf_unix",ring_vm_socket_constant_pf_unix);
+    ring_vm_funcregister("get_pf_file",ring_vm_socket_constant_pf_file);
+    ring_vm_funcregister("get_pf_inet",ring_vm_socket_constant_pf_inet);
+    ring_vm_funcregister("get_pf_inet6",ring_vm_socket_constant_pf_inet6);
+
+    ring_vm_funcregister("get_af_unspec",ring_vm_socket_constant_af_unspec);
+    ring_vm_funcregister("get_af_local",ring_vm_socket_constant_af_local);
+    ring_vm_funcregister("get_af_unix",ring_vm_socket_constant_af_unix);
+    ring_vm_funcregister("get_af_inet",ring_vm_socket_constant_af_inet);
+    ring_vm_funcregister("get_af_inet6",ring_vm_socket_constant_af_inet6);
+
+    ring_vm_funcregister("get_sock_stream",ring_vm_socket_constant_sock_stream);
+    ring_vm_funcregister("get_sock_dgram",ring_vm_socket_constant_sock_dgram);
+    ring_vm_funcregister("get_sock_raw",ring_vm_socket_constant_sock_raw);
+    ring_vm_funcregister("get_sock_rdm",ring_vm_socket_constant_sock_rdm);
+    ring_vm_funcregister("get_sock_seqpacket",ring_vm_socket_constant_sock_seqpacket);
+
+    ring_vm_funcregister("get_ipproto_ip",ring_vm_socket_constant_ipproto_ip);
+    ring_vm_funcregister("get_ipproto_tcp",ring_vm_socket_constant_ipproto_tcp);
+    ring_vm_funcregister("get_ipproto_udp",ring_vm_socket_constant_ipproto_udp);
+    ring_vm_funcregister("get_sol_socket",ring_vm_socket_constant_sol_socket);
+
+    ring_vm_funcregister("get_so_debug",ring_vm_socket_constant_so_debug);
+    ring_vm_funcregister("get_ip_add_membership",ring_vm_socket_constant_ip_add_membership);
+    ring_vm_funcregister("get_ip_add_source_membership",ring_vm_socket_constant_ip_add_source_membership);
+    ring_vm_funcregister("get_ip_block_source",ring_vm_socket_constant_ip_block_source);
+    ring_vm_funcregister("get_ip_drop_membership",ring_vm_socket_constant_ip_drop_membership);
+    ring_vm_funcregister("get_ip_drop_source_membership",ring_vm_socket_constant_ip_drop_source_membership);
+    ring_vm_funcregister("get_ip_hdrincl",ring_vm_socket_constant_ip_hdrincl);
+    ring_vm_funcregister("get_ip_mtu",ring_vm_socket_constant_ip_mtu);
+    ring_vm_funcregister("get_ip_mtu_discover",ring_vm_socket_constant_ip_mtu_discover);
+    ring_vm_funcregister("get_ip_multicast_loop",ring_vm_socket_constant_ip_multicast_loop);
+    ring_vm_funcregister("get_ip_multicast_ttl",ring_vm_socket_constant_ip_multicast_ttl);
+    ring_vm_funcregister("get_ip_options",ring_vm_socket_constant_ip_options);
+    ring_vm_funcregister("get_ip_pktinfo",ring_vm_socket_constant_ip_pktinfo);
+    ring_vm_funcregister("get_ip_recvtos",ring_vm_socket_constant_ip_recvtos);
+    ring_vm_funcregister("get_ip_recvttl",ring_vm_socket_constant_ip_recvttl);
+    ring_vm_funcregister("get_ip_tos",ring_vm_socket_constant_ip_tos);
+    ring_vm_funcregister("get_ip_ttl",ring_vm_socket_constant_ip_ttl);
+    ring_vm_funcregister("get_ip_unblock_source",ring_vm_socket_constant_ip_unblock_source);
+    ring_vm_funcregister("get_ip_unicast_if",ring_vm_socket_constant_ip_unicast_if);
+    ring_vm_funcregister("get_so_acceptconn",ring_vm_socket_constant_so_acceptconn);
+    ring_vm_funcregister("get_so_broadcast",ring_vm_socket_constant_so_broadcast);
+    ring_vm_funcregister("get_so_dontroute",ring_vm_socket_constant_so_dontroute);
+    ring_vm_funcregister("get_so_error",ring_vm_socket_constant_so_error);
+    ring_vm_funcregister("get_so_keepalive",ring_vm_socket_constant_so_keepalive);
+    ring_vm_funcregister("get_so_linger",ring_vm_socket_constant_so_linger);
+    ring_vm_funcregister("get_so_oobinline",ring_vm_socket_constant_so_oobinline);
+    ring_vm_funcregister("get_so_rcvbuf",ring_vm_socket_constant_so_rcvbuf);
+    ring_vm_funcregister("get_so_reuseaddr",ring_vm_socket_constant_so_reuseaddr);
+    ring_vm_funcregister("get_so_sndbuf",ring_vm_socket_constant_so_sndbuf);
+    ring_vm_funcregister("get_so_type",ring_vm_socket_constant_so_type);
+    ring_vm_funcregister("get_so_rcvlowat",ring_vm_socket_constant_so_rcvlowat);
+    ring_vm_funcregister("get_so_sndlowat",ring_vm_socket_constant_so_sndlowat);
+    ring_vm_funcregister("get_so_rcvtimeo",ring_vm_socket_constant_so_rcvtimeo);
 }
 
 

--- a/extensions/ringsockets/ext/sockets.c
+++ b/extensions/ringsockets/ext/sockets.c
@@ -793,14 +793,11 @@ RING_API void ringlib_init(RingState *pRingState) {
     /* Constants */
 
     ring_vm_funcregister("get_pf_unspec",ring_vm_socket_constant_pf_unspec);
-    ring_vm_funcregister("get_pf_local",ring_vm_socket_constant_pf_local);
     ring_vm_funcregister("get_pf_unix",ring_vm_socket_constant_pf_unix);
-    ring_vm_funcregister("get_pf_file",ring_vm_socket_constant_pf_file);
     ring_vm_funcregister("get_pf_inet",ring_vm_socket_constant_pf_inet);
     ring_vm_funcregister("get_pf_inet6",ring_vm_socket_constant_pf_inet6);
 
     ring_vm_funcregister("get_af_unspec",ring_vm_socket_constant_af_unspec);
-    ring_vm_funcregister("get_af_local",ring_vm_socket_constant_af_local);
     ring_vm_funcregister("get_af_unix",ring_vm_socket_constant_af_unix);
     ring_vm_funcregister("get_af_inet",ring_vm_socket_constant_af_inet);
     ring_vm_funcregister("get_af_inet6",ring_vm_socket_constant_af_inet6);

--- a/extensions/ringsockets/ext/sockets.h
+++ b/extensions/ringsockets/ext/sockets.h
@@ -1,7 +1,7 @@
 #ifndef ring_socket_h
 #define ring_socket_h
 
-
+#include "constants.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -45,6 +45,9 @@
 
     } RING_SOCKET;
 #endif
+
+
+#include "ring.h"
 
 
 void ring_vm_socket_init(void *pPointer);

--- a/extensions/ringsockets/lib/constants.ring
+++ b/extensions/ringsockets/lib/constants.ring
@@ -5,111 +5,68 @@
 */
 
 # Protocol Families
-    PF_UNSPEC       = 0
-    PF_UNIX         = 1
-    PF_INET         = 2
-    if isWindows()
-        PF_INET6        = 23
-    else
-        PF_INET6        = 10
-    ok
+    PF_UNSPEC       = get_PF_UNSPEC()
+    PF_LOCAL        = get_PF_LOCAL()
+    PF_UNIX         = get_PF_UNIX()
+    PF_FILE         = get_PF_FILE()
+    PF_INET         = get_PF_INET()
+    PF_INET6        = get_PF_INET6()
 
 # Address Families
-    AF_UNSPEC       = 0
-    AF_LOCAL        = 1
-    AF_UNIX         = PF_UNIX
-    PF_FILE         = 1
-    AF_INET         = 2
-    AF_INET6        = PF_INET6
+    AF_UNSPEC       = get_AF_UNSPEC()
+    AF_LOCAL        = get_AF_LOCAL()
+    AF_UNIX         = get_AF_UNIX()
+    AF_INET         = get_AF_INET()
+    AF_INET6        = get_AF_INET6()
 
 # Connection Types
-    SOCK_STREAM     = 1
-    SOCK_DGRAM      = 2
-    SOCK_RAW        = 3
-    SOCK_RDM        = 4
-    SOCK_SEQPACKET  = 5
+    SOCK_STREAM     = get_SOCK_STREAM()
+    SOCK_DGRAM      = get_SOCK_DGRAM()
+    SOCK_RAW        = get_SOCK_RAW()
+    SOCK_RDM        = get_SOCK_RDM()
+    SOCK_SEQPACKET  = get_SOCK_SEQPACKET()
 
 # Levels
-    IPPROTO_IP      = 0
-    IPPROTO_TCP     = 6
-    IPPROTO_UDP     = 17
-    if isWindows()
-        SOL_SOCKET      = dec("0xffff")
-    else
-        SOL_SOCKET      = 1
-    ok
+    IPPROTO_IP      = get_IPPROTO_IP()
+    IPPROTO_TCP     = get_IPPROTO_TCP()
+    IPPROTO_UDP     = get_IPPROTO_UDP()
+    SOL_SOCKET      = get_SOL_SOCKET()
 
 # Option names
-    SO_DEBUG            = 1
+    SO_DEBUG            = get_SO_DEBUG()
 
-    if isWindows()
-        IP_ADD_MEMBERSHIP   = 12
-        IP_ADD_SOURCE_MEMBERSHIP = 15
-        IP_BLOCK_SOURCE     = 17
-        IP_DROP_MEMBERSHIP  = 13
-        IP_DROP_SOURCE_MEMBERSHIP = 16
-        IP_HDRINCL          = 2
-        IP_MTU              = 70
-        IP_MTU_DISCOVER     = 71
-        IP_MULTICAST_LOOP   = 11
-        IP_MULTICAST_TTL    = 10
-        IP_OPTIONS          = 1
-        IP_PKTINFO          = 19
-        IP_RECVTOS          = 40
-        IP_RECVTTL          = 21
-        IP_TOS              = 3
-        IP_TTL              = 4
-        IP_UNBLOCK_SOURCE   = 18
-        IP_UNICAST_IF       = 31
-
-
-        SO_ACCEPTCONN       = dec("0x0002")
-        SO_BROADCAST        = dec("0x0020")
-        SO_DONTROUTE        = dec("0x0010")
-        SO_ERROR            = dec("0x1007")
-        SO_KEEPALIVE        = dec("0x0008")
-        SO_LINGER           = dec("0x0080")
-        SO_OOBINLINE        = dec("0x0100")
-        SO_RCVBUF           = dec("0x1002")
-        SO_REUSEADDR        = dec("0x0004")
-        SO_SNDBUF           = dec("0x1001")
-        SO_TYPE             = dec("0x1008")
-        SO_RCVLOWAT         = dec("0x1004")
-        SO_SNDLOWAT         = dec("0x1003")
-        SO_RCVTIMEO         = dec("0x1006")
-    else
-        IP_ADD_MEMBERSHIP   = 35
-        IP_ADD_SOURCE_MEMBERSHIP = 39
-        IP_BLOCK_SOURCE     = 38
-        IP_DROP_MEMBERSHIP  = 36
-        IP_DROP_SOURCE_MEMBERSHIP = 40
-        IP_HDRINCL          = 3
-        IP_MTU              = 14
-        IP_MTU_DISCOVER     = 10
-        IP_MULTICAST_LOOP   = 34
-        IP_MULTICAST_TTL    = 33
-        IP_OPTIONS          = 4
-        IP_PKTINFO          = 8
-        IP_RECVTOS          = 13
-        IP_RECVTTL          = 12
-        IP_TOS              = 1
-        IP_TTL              = 2
-        IP_UNBLOCK_SOURCE   = 37
-        IP_UNICAST_IF       = 50
+    IP_ADD_MEMBERSHIP   = get_IP_ADD_MEMBERSHIP()
+    IP_ADD_SOURCE_MEMBERSHIP = get_IP_ADD_SOURCE_MEMBERSHIP()
+    IP_BLOCK_SOURCE     = get_IP_BLOCK_SOURCE()
+    IP_DROP_MEMBERSHIP  = get_IP_DROP_MEMBERSHIP()
+    IP_DROP_SOURCE_MEMBERSHIP = get_IP_DROP_SOURCE_MEMBERSHIP()
+    IP_HDRINCL          = get_IP_HDRINCL()
+    IP_MTU              = get_IP_MTU()
+    IP_MTU_DISCOVER     = get_IP_MTU_DISCOVER()
+    IP_MULTICAST_LOOP   = get_IP_MULTICAST_LOOP()
+    IP_MULTICAST_TTL    = get_IP_MULTICAST_TTL()
+    IP_OPTIONS          = get_IP_OPTIONS()
+    IP_PKTINFO          = get_IP_PKTINFO()
+    IP_RECVTOS          = get_IP_RECVTOS()
+    IP_RECVTTL          = get_IP_RECVTTL()
+    IP_TOS              = get_IP_TOS()
+    IP_TTL              = get_IP_TTL()
+    IP_UNBLOCK_SOURCE   = get_IP_UNBLOCK_SOURCE()
+    IP_UNICAST_IF       = get_IP_UNICAST_IF()
 
 
-        SO_ACCEPTCONN       = 30
-        SO_BROADCAST        = 6
-        SO_DONTROUTE        = 5
-        SO_ERROR            = 4
-        SO_KEEPALIVE        = 9
-        SO_LINGER           = 13
-        SO_OOBINLINE        = 10
-        SO_RCVBUF           = 8
-        SO_REUSEADDR        = 2
-        SO_SNDBUF           = 7
-        SO_TYPE             = 3
-        SO_RCVLOWAT         = 18
-        SO_SNDLOWAT         = 19
-        SO_RCVTIMEO         = 20
-    ok
+    SO_ACCEPTCONN       = get_SO_ACCEPTCONN()
+    SO_BROADCAST        = get_SO_BROADCAST()
+    SO_DONTROUTE        = get_SO_DONTROUTE()
+    SO_ERROR            = get_SO_ERROR()
+    SO_KEEPALIVE        = get_SO_KEEPALIVE()
+    SO_LINGER           = get_SO_LINGER()
+    SO_OOBINLINE        = get_SO_OOBINLINE()
+    SO_RCVBUF           = get_SO_RCVBUF()
+    SO_REUSEADDR        = get_SO_REUSEADDR()
+    SO_SNDBUF           = get_SO_SNDBUF()
+    SO_TYPE             = get_SO_TYPE()
+    SO_RCVLOWAT         = get_SO_RCVLOWAT()
+    SO_SNDLOWAT         = get_SO_SNDLOWAT()
+    SO_RCVTIMEO         = get_SO_RCVTIMEO()
+    

--- a/extensions/ringsockets/lib/constants.ring
+++ b/extensions/ringsockets/lib/constants.ring
@@ -6,15 +6,12 @@
 
 # Protocol Families
     PF_UNSPEC       = get_PF_UNSPEC()
-    PF_LOCAL        = get_PF_LOCAL()
     PF_UNIX         = get_PF_UNIX()
-    PF_FILE         = get_PF_FILE()
     PF_INET         = get_PF_INET()
     PF_INET6        = get_PF_INET6()
 
 # Address Families
     AF_UNSPEC       = get_AF_UNSPEC()
-    AF_LOCAL        = get_AF_LOCAL()
     AF_UNIX         = get_AF_UNIX()
     AF_INET         = get_AF_INET()
     AF_INET6        = get_AF_INET6()

--- a/extensions/ringsockets/sockets.ring
+++ b/extensions/ringsockets/sockets.ring
@@ -5,8 +5,6 @@
 */
 
 
-Load "lib/constants.ring"
-
 if iswindows()
         LoadLib("ring_sockets.dll")
 but ismacosx()
@@ -14,3 +12,5 @@ but ismacosx()
 else
         LoadLib("libring_sockets.so")
 ok
+
+Load "lib/constants.ring"


### PR DESCRIPTION
Socket constants are different in operating systems, so extending them is better than defining them hard coded to avoid wrong values in different systems .