### PR TITLE
Add function Getfilesize that is more reliable & faster than Fsize from Stdlib.ring

### DIFF
--- a/language/include/ring_file_extension.h
+++ b/language/include/ring_file_extension.h
@@ -64,6 +64,8 @@
     void ring_vm_file_direxists ( void *pPointer ) ;
 
     void ring_vm_file_getpathtype ( void *pPointer ) ;
+	
+	void ring_vm_file_getfilesize ( void *pPointer ) ;
     /* Number & Bytes */
 
     void ring_vm_file_int2bytes ( void *pPointer ) ;

--- a/language/src/ring_file_extension.c
+++ b/language/src/ring_file_extension.c
@@ -34,6 +34,7 @@ void ring_vm_file_loadfunctions ( RingState *pRingState )
     ring_vm_funcregister("fexists",ring_vm_file_fexists);
     ring_vm_funcregister("direxists",ring_vm_file_direxists);
     ring_vm_funcregister("getpathtype",ring_vm_file_getpathtype);
+	ring_vm_funcregister("getfilesize",ring_vm_file_getfilesize);
     ring_vm_funcregister("int2bytes",ring_vm_file_int2bytes);
     ring_vm_funcregister("float2bytes",ring_vm_file_float2bytes);
     ring_vm_funcregister("double2bytes",ring_vm_file_double2bytes);
@@ -102,6 +103,19 @@ int ring_getpathtype ( const char *cDirPath )
         return -1 ;
     }
     return 0 ;
+}
+
+RING_LONGLONG ring_getfilesize ( const char *cFilePath )
+{
+    struct stat sb  ;
+    if ( stat(cFilePath, &sb) == 0 ) {
+        if ( S_ISREG(sb.st_mode) ) {
+            /* Path exists and it is a regular file */
+            return (RING_LONGLONG) sb.st_size ;
+        }
+    }
+	/* doesn't exist or not a file */
+    return (RING_LONGLONG) -1 ;
 }
 
 void ring_vm_file_fopen ( void *pPointer )
@@ -801,6 +815,20 @@ void ring_vm_file_getpathtype ( void *pPointer )
     }
     if ( RING_API_ISSTRING(1) ) {
         RING_API_RETNUMBER(ring_getpathtype(RING_API_GETSTRING(1)));
+    }
+    else {
+        RING_API_ERROR(RING_API_BADPARATYPE);
+    }
+}
+
+void ring_vm_file_getfilesize ( void *pPointer )
+{
+    if ( RING_API_PARACOUNT != 1 ) {
+        RING_API_ERROR(RING_API_MISS1PARA);
+        return ;
+    }
+    if ( RING_API_ISSTRING(1) ) {
+        RING_API_RETNUMBER(ring_getfilesize(RING_API_GETSTRING(1)));
     }
     else {
         RING_API_ERROR(RING_API_BADPARATYPE);


### PR DESCRIPTION
Benchmarks show that this new function is at least 20% faster than `Fsize` that is available in `Stdlib.ring`.
Its implementation uses the C `stat` function that gets the information about file size directly from the filesystem without requiring any I/O. This makes it much faster than using `fopen->fseek->ftell->fclose`.
Moreover, there are situations where `fopen` will fail because of sharing violation and so `fseek`/`ftell` cannot be used to get the file size in this case. The C `stat` function doesn't suffer from this issue.

### **Getfilesize() Function**

We can get the size in bytes of a given file using the Getfilesize() function

**Syntax:**

Getfilesize(cFilePath) ---> file size in bytes as a positive Number or -1 in case of failure (e.g. path doesn't exist or not a regular file)

**Example:**

```
? Getfilesize("b:\ring\bin\ring.exe") + nl +
	  Getfilesize("b:\ring") + nl +
	  Getfilesize("b:\ring\ring2.exe") 
```

**Output:**

```
80384
-1
-1
```