### PR TITLE
Add missing winapi.ring and wincreg.ring from bin/load

### DIFF
--- a/bin/load/winapi.ring
+++ b/bin/load/winapi.ring
@@ -1,0 +1,1 @@
+load "/../../extensions/ringwinapi/bin/winapi.ring"

--- a/bin/load/wincreg.ring
+++ b/bin/load/wincreg.ring
@@ -1,0 +1,1 @@
+load "/../../extensions/ringwincreg/bin/wincreg.ring"


### PR DESCRIPTION
Without these files, the statements '`Load "winapi.ring"`' and '`Load "wincreg.ring"`' fail despite the fact that ring_winapi.dll and ring_wincreg.dll are part of official Windows distribution.