### PR TITLE
Fix uptime bug on Windows if high resolution timer frequency is more than 10Mhz

### DIFF
--- a/language/src/ring_os_extension.c
+++ b/language/src/ring_os_extension.c
@@ -297,9 +297,11 @@ void ring_vm_os_uptime ( void *pPointer )
 {
     double nTime  ;
     #ifdef _WIN32
-        LARGE_INTEGER ElapsedMicroseconds  ;
-        QueryPerformanceCounter(&ElapsedMicroseconds);
-        nTime = ElapsedMicroseconds.QuadPart ;
+        LARGE_INTEGER PerformanceCounterTicks, PerformanceCounterFrequency ;
+		QueryPerformanceFrequency(&PerformanceCounterFrequency);
+        QueryPerformanceCounter(&PerformanceCounterTicks);
+		/* return the elapsed time in units of 0.1 microseconds for backward compatibility */ 
+        nTime = ((double) PerformanceCounterTicks.QuadPart / (double) PerformanceCounterFrequency.QuadPart) * (double) 10000000.0;
     #else
         struct timespec ts  ;
         ring_vm_os_gettime(CLOCK_UPTIME, &ts);


### PR DESCRIPTION
`QueryPerformanceCounter` returns the number of ticks of the high resolution timer and the previous code was assuming that its frequency is always 10Mhz which is not always true. `QueryPerformanceFrequency` must be called to get the effective frequency.

https://docs.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter
https://docs.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancefrequency
https://docs.microsoft.com/fr-fr/windows/win32/sysinfo/acquiring-high-resolution-time-stamps