### PR TITLE
Windows build batch files enhancements: better setlocal usage, use 'call' in locatevc.bat to run buildarch.ring

### DIFF
--- a/extensions/ringallegro/buildvc_allegro5.2.7.1.bat
+++ b/extensions/ringallegro/buildvc_allegro5.2.7.1.bat
@@ -1,8 +1,10 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ring_allegro.c -I"..\..\extensions\libdepwin\allegro5.2.7.1\include" -I"..\..\language\include"
 link /DEBUG ring_allegro.obj  ..\..\lib\ring.lib ..\..\extensions\libdepwin\allegro5.2.7.1\lib\allegro.lib ..\..\extensions\libdepwin\allegro5.2.7.1\lib\allegro_image.lib ..\..\extensions\libdepwin\allegro5.2.7.1\lib\allegro_dialog.lib ..\..\extensions\libdepwin\allegro5.2.7.1\lib\allegro_ttf.lib ..\..\extensions\libdepwin\allegro5.2.7.1\lib\allegro_acodec.lib ..\..\extensions\libdepwin\allegro5.2.7.1\lib\allegro_primitives.lib ^
 ..\..\extensions\libdepwin\allegro5.2.7.1\lib\allegro_audio.lib ..\..\extensions\libdepwin\allegro5.2.7.1\lib\allegro_color.lib ..\..\extensions\libdepwin\allegro5.2.7.1\lib\allegro_font.lib ..\..\extensions\libdepwin\allegro5.2.7.1\lib\allegro_video.lib ..\..\extensions\libdepwin\allegro5.2.7.1\lib\allegro_primitives.lib ..\..\extensions\libdepwin\allegro5.2.7.1\lib\allegro_memfile.lib ^
 		..\..\extensions\libdepwin\allegro5.2.7.1\lib\allegro_physfs.lib ^
 	  /DLL /OUT:..\..\bin\ring_allegro.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ring_allegro.obj
+endlocal

--- a/extensions/ringbeep/buildvc.bat
+++ b/extensions/ringbeep/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ringbeep.c -I"..\..\language\include"
 link /DEBUG ringbeep.obj  ..\..\lib\ring.lib kernel32.lib /DLL /OUT:ringbeep.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ringbeep.obj
+endlocal

--- a/extensions/ringcjson/buildvc.bat
+++ b/extensions/ringcjson/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ring_cjson.c lib/cJSON.c lib/cJSON_Utils.c -I"..\..\language\include"
 link /DEBUG ring_cjson.obj cJSON.obj cJSON_Utils.obj ..\..\lib\ring.lib /DLL /OUT:..\..\bin\ring_cjson.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ring_cjson.obj
+endlocal

--- a/extensions/ringconsolecolors/buildvc.bat
+++ b/extensions/ringconsolecolors/buildvc.bat
@@ -1,5 +1,5 @@
 cls
-setlocal 
+setlocal enableextensions enabledelayedexpansion
 rem buildvc.bat [debug]
 rem we pass the parameter as second parameter to locatevc.bat
 call ../../language/src/locatevc.bat auto %1

--- a/extensions/ringcurl/buildvc.bat
+++ b/extensions/ringcurl/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ring_libcurl.c -I"..\..\extensions\libdepwin\libcurl\include" -I"..\..\language\include"
 link /DEBUG ring_libcurl.obj  ..\..\lib\ring.lib ..\..\extensions\libdepwin\libcurl\lib\libcurl.lib /DLL /OUT:..\..\bin\ring_libcurl.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ring_libcurl.obj
+endlocal

--- a/extensions/ringfreeglut/buildvc.bat
+++ b/extensions/ringfreeglut/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ring_freeglut.c -I "..\..\extensions\libdepwin\freeglut\include" -I"..\..\language\include"
 link /DEBUG ring_freeglut.obj  ..\..\lib\ring.lib ..\..\extensions\libdepwin\freeglut\lib\freeglut.lib /DLL /OUT:..\..\bin\ring_freeglut.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ring_freeglut.obj
+endlocal

--- a/extensions/ringhttplib/buildvc.bat
+++ b/extensions/ringhttplib/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /EHsc /c ring_httplib.cpp -I"..\..\language\include"
 link ring_httplib.obj  ..\..\lib\ring.lib /DLL /OUT:..\..\bin\ring_httplib.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ring_httplib.obj
+endlocal

--- a/extensions/ringhttplib/cpptest/buildvc.bat
+++ b/extensions/ringhttplib/cpptest/buildvc.bat
@@ -1,3 +1,5 @@
 cls
-call ../../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../../language/src/locatevc.bat auto %1
 cl /EHsc test.cpp
+endlocal

--- a/extensions/ringinternet/buildvc.bat
+++ b/extensions/ringinternet/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ring_internet.c -I"..\..\extensions\libdepwin\libcurl\include" -I"..\..\language\include"
 link /DEBUG ring_internet.obj  ..\..\lib\ring.lib ..\..\extensions\libdepwin\libcurl\lib\libcurl.lib /DLL /OUT:..\..\bin\ring_internet.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ring_internet.obj
+endlocal

--- a/extensions/ringlibui/buildvc.bat
+++ b/extensions/ringlibui/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ring_libui.c -I "..\..\extensions\libdepwin\libuishared" -I"..\..\language\include"
 link /DEBUG ring_libui.obj  ..\..\lib\ring.lib ..\..\extensions\libdepwin\libuishared\libui.lib /DLL /OUT:..\..\bin\ring_libui.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ring_libui.obj
+endlocal

--- a/extensions/ringlibuv/buildvc.bat
+++ b/extensions/ringlibuv/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /W2 /O2 /c /DEBUG ring_libuv.c -I"..\..\extensions\libdepwin\libuv\include" -I"..\..\language\include"
 link /DEBUG ring_libuv.obj  ..\..\lib\ring.lib ..\..\extensions\libdepwin\libuv\libuv.lib /DLL /OUT:..\..\bin\ring_uv.dll /SUBSYSTEM:WINDOWS,"5.01" /NODEFAULTLIB:msvcrt.lib
 del ring_libuv.obj
+endlocal

--- a/extensions/ringmouseevent/buildvc.bat
+++ b/extensions/ringmouseevent/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ringmouseevent.c -I"..\..\language\include"
 link /DEBUG ringmouseevent.obj  ..\..\lib\ring.lib kernel32.lib user32.lib /DLL /OUT:ringmouseevent.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ringmouseevent.obj
+endlocal

--- a/extensions/ringmurmurhash/buildvc.bat
+++ b/extensions/ringmurmurhash/buildvc.bat
@@ -1,7 +1,9 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ring_murmurhash.c libmurmurhash/MurmurHash1.c ^
     libmurmurhash/MurmurHash2.c libmurmurhash/MurmurHash3.c ^
      -I"../../language/include" -I"libmurmurhash/"
 link /DEBUG *.obj ..\..\lib\ring.lib /DLL /OUT:..\..\bin\ring_murmurhash.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del *.obj
+endlocal

--- a/extensions/ringmysql/buildvc.bat
+++ b/extensions/ringmysql/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ring_vmmysql.c -I"..\..\language\include" -I"..\..\extensions\libdepwin\mysql\include" 
 link /DEBUG ring_vmmysql.obj  ..\..\lib\ring.lib ..\..\extensions\libdepwin\MySQL\lib\libmysql.lib /DLL /OUT:..\..\bin\ring_mysql.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ring_vmmysql.obj
+endlocal

--- a/extensions/ringodbc/buildvc.bat
+++ b/extensions/ringodbc/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ring_vmodbc.c -I"..\..\language\include"
 link /DEBUG ring_vmodbc.obj  ..\..\lib\ring.lib odbc32.lib /DLL /OUT:..\..\bin\ring_odbc.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ring_vmodbc.obj
+endlocal

--- a/extensions/ringopenssl/buildvc.bat
+++ b/extensions/ringopenssl/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ring_vmopenssl.c -I"..\..\language\include" -I"..\..\extensions\libdepwin\OPENSSL\include"
 link /DEBUG ring_vmopenssl.obj  ..\..\lib\ring.lib ..\..\extensions\libdepwin\OpenSSL\lib\libeay32.lib /DLL /OUT:..\..\bin\ring_openssl.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ring_vmopenssl.obj
+endlocal

--- a/extensions/ringpostgresql/buildvc.bat
+++ b/extensions/ringpostgresql/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ring_pgsql.c -I"..\..\extensions\libdepwin\pgsql\include" -I"..\..\language\include"
 link /DEBUG ring_pgsql.obj  ..\..\lib\ring.lib ..\..\extensions\libdepwin\pgsql\lib\libpq.lib /DLL /OUT:..\..\bin\ring_pgsql.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ring_pgsql.obj
+endlocal

--- a/extensions/ringqt/buildqt512.bat
+++ b/extensions/ringqt/buildqt512.bat
@@ -1,5 +1,7 @@
-call ..\..\language\src\locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ..\..\language\src\locatevc.bat auto %1
 "C:\Qt\Qt5.12.6\5.12.6\msvc2017\bin\qmake.exe" ring_qt512.pro -spec win32-msvc "CONFIG+=qtquickcompiler"
 rem "C:\Qt\Qt5.12.6\Tools\QtCreator\bin\jom.exe" -f ../build-ring_qt512-Desktop_Qt_5_12_3_MSVC2017_32bit-Release/Makefile qmake_all
 "C:\Qt\Qt5.12.6\Tools\QtCreator\bin\jom.exe"
 copy release\ringqt.dll ..\..\bin
+endlocal

--- a/extensions/ringqt/buildqt512_light.bat
+++ b/extensions/ringqt/buildqt512_light.bat
@@ -1,5 +1,7 @@
-call ..\..\language\src\locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ..\..\language\src\locatevc.bat auto %1
 "C:\Qt\Qt5.12.6\5.12.6\msvc2017\bin\qmake.exe" ring_qt512_light.pro -spec win32-msvc "CONFIG+=release"
 rem "C:\Qt\Qt5.12.6\Tools\QtCreator\bin\jom.exe" -f ../build-ring_qt512-Desktop_Qt_5_12_6_MSVC2017_32bit-Release/Makefile qmake_all
 "C:\Qt\Qt5.12.6\Tools\QtCreator\bin\jom.exe"
 copy release\ringqt_light.dll ..\..\bin
+endlocal

--- a/extensions/ringqt/buildqt512_nobluetooth.bat
+++ b/extensions/ringqt/buildqt512_nobluetooth.bat
@@ -1,5 +1,8 @@
-call ..\..\language\src\locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ..\..\language\src\locatevc.bat auto %1
 "C:\Qt\Qt5.12.6\5.12.6\msvc2017\bin\qmake.exe" ring_qt512_nobluetooth.pro -spec win32-msvc "CONFIG+=qtquickcompiler"
 rem "C:\Qt\Qt5.12.6\Tools\QtCreator\bin\jom.exe" -f ../build-ring_qt512-Desktop_Qt_5_12_3_MSVC2017_32bit-Release/Makefile qmake_all
 "C:\Qt\Qt5.12.6\Tools\QtCreator\bin\jom.exe"
 copy release\ringqt.dll ..\..\bin
+endlocal
+

--- a/extensions/ringqt/buildqt515.bat
+++ b/extensions/ringqt/buildqt515.bat
@@ -1,4 +1,6 @@
-call ..\..\language\src\locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ..\..\language\src\locatevc.bat auto %1
 "C:\Qt\5.15.0\msvc2019\bin\qmake.exe" ring_qt512.pro -spec win32-msvc "CONFIG+=qtquickcompiler"
 "C:\Qt\Tools\QtCreator\bin\jom\jom.exe"
 copy release\ringqt.dll ..\..\bin
+endlocal

--- a/extensions/ringqt/buildqt515_core.bat
+++ b/extensions/ringqt/buildqt515_core.bat
@@ -1,4 +1,7 @@
-call ..\..\language\src\locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ..\..\language\src\locatevc.bat auto %1
 "C:\Qt\5.15.0\msvc2019\bin\qmake.exe" ring_qt515_core.pro -spec win32-msvc "CONFIG+=qtquickcompiler"
 "C:\Qt\Tools\QtCreator\bin\jom\jom.exe"
 copy release\ringqt_core.dll ..\..\bin
+endlocal
+

--- a/extensions/ringqt/buildqt515_light.bat
+++ b/extensions/ringqt/buildqt515_light.bat
@@ -1,4 +1,6 @@
-call ..\..\language\src\locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ..\..\language\src\locatevc.bat auto %1
 "C:\Qt\5.15.0\msvc2019\bin\qmake.exe" ring_qt512_light.pro -spec win32-msvc "CONFIG+=release"
 "C:\Qt\Tools\QtCreator\bin\jom\jom.exe"
 copy release\ringqt_light.dll ..\..\bin
+endlocal

--- a/extensions/ringqt/buildqt515_nobluetooth.bat
+++ b/extensions/ringqt/buildqt515_nobluetooth.bat
@@ -1,4 +1,6 @@
-call ..\..\language\src\locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ..\..\language\src\locatevc.bat auto %1
 "C:\Qt\5.15.0\msvc2019\bin\qmake.exe" ring_qt512_nobluetooth.pro -spec win32-msvc "CONFIG+=qtquickcompiler"
 "C:\Qt\Tools\QtCreator\bin\jom\jom.exe"
 copy release\ringqt.dll ..\..\bin
+endlocal

--- a/extensions/ringqt/buildvc.bat
+++ b/extensions/ringqt/buildvc.bat
@@ -1,3 +1,5 @@
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 "C:\Qt\Qt5.5.0\5.5\msvc2013\bin\qmake.exe" B:\ring\extensions\ringqt\ring_qt.pro -r -spec win32-msvc2013
 "C:\Qt\Qt5.5.0\Tools\QtCreator\bin\jom.exe" 
+endlocal

--- a/extensions/ringraylib/src/buildvc.bat
+++ b/extensions/ringraylib/src/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../../language/src/locatevc.bat auto %1
 cl /W2 /O2 /c /DEBUG ring_raylib.c -I"..\..\..\extensions\libdepwin\raylib2.5\include" -I"..\..\..\language\include"
 link /DEBUG ring_raylib.obj  ..\..\..\lib\ring.lib ..\..\..\extensions\libdepwin\raylib2.5\lib\raylib.lib  /DLL /OUT:..\..\..\bin\ring_raylib.dll 
 del ring_raylib.obj
+endlocal

--- a/extensions/ringsdl/buildvc.bat
+++ b/extensions/ringsdl/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ring_libsdl.c -I"..\..\extensions\libdepwin\libsdl\sdl2_vc\include" -I"..\..\extensions\libdepwin\libsdl\sdl2_image\include" -I"..\..\extensions\libdepwin\libsdl\sdl2_ttf\include" -I"..\..\extensions\libdepwin\libsdl\sdl2_mixer\include" -I"..\..\extensions\libdepwin\libsdl\sdl2_net\include" -I"sdl2_gfx" -I"..\..\language\include"
 link /DEBUG ring_libsdl.obj  ..\..\lib\ring.lib ..\..\extensions\libdepwin\libsdl\sdl2_vc\lib\x86\sdl2.lib ..\..\extensions\libdepwin\libsdl\sdl2_image\lib\x86\sdl2_image.lib ..\..\extensions\libdepwin\libsdl\sdl2_ttf\lib\x86\sdl2_ttf.lib ..\..\extensions\libdepwin\libsdl\sdl2_mixer\lib\x86\sdl2_mixer.lib ..\..\extensions\libdepwin\libsdl\sdl2_net\lib\x86\sdl2_net.lib ..\..\extensions\libdepwin\libsdl\sdl2_vc\lib\x86\sdl2main.lib /DLL /OUT:..\..\bin\ring_sdl.dll /SUBSYSTEM:WINDOWS,"5.01" /NODEFAULTLIB:msvcrt.lib
 del ring_libsdl.obj
+endlocal

--- a/extensions/ringsockets/buildvc.bat
+++ b/extensions/ringsockets/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ext\*.c -I"..\..\language\include" -I"ext\"
 link /DEBUG *.obj  ..\..\lib\ring.lib /DLL /OUT:..\..\bin\ring_sockets.dll /SUBSYSTEM:CONSOLE,"5.01"
 del *.obj
+endlocal

--- a/extensions/ringsqlite/buildvc.bat
+++ b/extensions/ringsqlite/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ring_vmsqlite.c sqlite3.c -I"..\..\language\include"  
 link /DEBUG ring_vmsqlite.obj sqlite3.obj  ..\..\lib\ring.lib /DLL /OUT:..\..\bin\ring_sqlite.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del *.obj
+endlocal

--- a/extensions/ringstbimage/buildvc.bat
+++ b/extensions/ringstbimage/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ring_stbimage.c -I"..\..\language\include"
 link /DEBUG ring_stbimage.obj  ..\..\lib\ring.lib /DLL /OUT:..\..\bin\ring_stbimage.dll  /SUBSYSTEM:CONSOLE,"5.01" 
 del ring_stbimage.obj
+endlocal

--- a/extensions/ringthreads/buildvc.bat
+++ b/extensions/ringthreads/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /nologo /W2 /O2 /c /DEBUG ring_threads.c -I"..\..\language\include"
 link /DEBUG ring_threads.obj  ..\..\lib\ring.lib /DLL /OUT:..\..\bin\ring_threads.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ring_threads.obj
+endlocal

--- a/extensions/ringtilengine/buildvc.bat
+++ b/extensions/ringtilengine/buildvc.bat
@@ -1,5 +1,8 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /W2 /O2 /c /DEBUG ring_tilengine.c -I "..\..\extensions\libdepwin\tilengine\include" -I"..\..\language\include"
 link /DEBUG ring_tilengine.obj  ..\..\lib\ring.lib ..\..\extensions\libdepwin\tilengine\lib\tilengine.lib /DLL /OUT:..\..\bin\ring_tilengine.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ring_tilengine.obj
+endlocal
+

--- a/extensions/ringwinapi/buildvc.bat
+++ b/extensions/ringwinapi/buildvc.bat
@@ -1,6 +1,6 @@
 echo off
-
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 
 cl /c /DEBUG ring_winapi.c -I"..\..\language\include"
 
@@ -15,5 +15,5 @@ del ring_winapi.pdb
 del ring_winapi.lib
 del ring_winapi.dll
 
-
+endlocal
 

--- a/extensions/ringwincreg/buildvc.bat
+++ b/extensions/ringwincreg/buildvc.bat
@@ -1,6 +1,6 @@
 echo off
-
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 
 cl /c /DEBUG /EHsc creg_registry.cpp ring_wincreg.cpp -I"..\..\language\include"
 
@@ -17,4 +17,4 @@ del ring_wincreg.pdb
 del ring_wincreg.dll
 del ring_wincreg.lib
 
-
+endlocal

--- a/extensions/ringzip/buildvc.bat
+++ b/extensions/ringzip/buildvc.bat
@@ -1,5 +1,7 @@
 cls
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 cl /c /DEBUG ring_libzip.c -I"..\ringzip" -I"..\..\language\include"
 link /DEBUG ring_libzip.obj  ..\..\lib\ring.lib /DLL /OUT:..\..\bin\ring_libzip.dll /SUBSYSTEM:CONSOLE,"5.01" 
 del ring_libzip.obj
+endlocal

--- a/language/src/buildvc.bat
+++ b/language/src/buildvc.bat
@@ -1,5 +1,5 @@
 echo off
-setlocal
+setlocal enableextensions enabledelayedexpansion
 call locatevc.bat %1 %2
 
 cls 

--- a/language/src/buildvc_debug.bat
+++ b/language/src/buildvc_debug.bat
@@ -1,5 +1,5 @@
 echo off
-setlocal
+setlocal enableextensions enabledelayedexpansion
 call locatevc.bat %1 %2
 
 cls 

--- a/language/src/buildvcstatic.bat
+++ b/language/src/buildvcstatic.bat
@@ -1,5 +1,5 @@
 echo off
-setlocal
+setlocal enableextensions enabledelayedexpansion
 call locatevc.bat %1 %2
 
 cls

--- a/language/src/buildvcw.bat
+++ b/language/src/buildvcw.bat
@@ -1,5 +1,5 @@
 echo off
-setlocal
+setlocal enableextensions enabledelayedexpansion
 call locatevc.bat %1 %2
 
 cls

--- a/language/src/locatevc.bat
+++ b/language/src/locatevc.bat
@@ -29,7 +29,7 @@ if /I ["%1"]==["auto"] (
 	if exist %RINGEXEPATH% (
 		rem run buildarch.ring to get ring.exe architecture
 		rem we use trick documented at https://devblogs.microsoft.com/oldnewthing/20120731-00/?p=7003
-		for /f %%i in ('%RINGEXEPATH% %RINGARCHPATH%') do set ringbuildtarget=%%i
+		for /f %%i in ('call %RINGEXEPATH% %RINGARCHPATH%') do set ringbuildtarget=%%i
 	)
 )
 

--- a/tools/folder2qrc/build.bat
+++ b/tools/folder2qrc/build.bat
@@ -1,3 +1,5 @@
-call ..\..\language\src\locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ..\..\language\src\locatevc.bat auto %1
 ring2exe folder2qrc.ring -static
 copy folder2qrc.exe ..\..\bin\folder2qrc.exe
+endlocal

--- a/tools/ring2exe/buildring2exe.bat
+++ b/tools/ring2exe/buildring2exe.bat
@@ -1,4 +1,4 @@
-setlocal
+setlocal enableextensions enabledelayedexpansion
 
 set RINGSCRIPTPATH=%~dp0
 set RINGEXEPATH="%RINGSCRIPTPATH%..\..\bin\ring.exe"

--- a/tools/ring2exe/ring2exe.ring
+++ b/tools/ring2exe/ring2exe.ring
@@ -270,7 +270,7 @@ func GenerateBatchGeneral aPara,aOptions
 		if cBuildtarget = "unknown"
 			cBuildtarget = "x86"
 		ok
-		cCode = "setlocal" + nl + "call "+exefolder()+"../language/src/locatevc.bat " + cBuildtarget + nl +
+		cCode = "setlocal enableextensions enabledelayedexpansion" + nl + "call "+exefolder()+"../language/src/locatevc.bat " + cBuildtarget + nl +
 			"#{f3}" + nl +
 			'cl /O2 #{f1}.c #{f2} #{f4} -I"#{f6}..\language\include" -I"#{f6}../language/src/" /link #{f5} /OUT:#{f1}.exe' + nl +
 			"endlocal" + nl 

--- a/tools/ringnotepad/rnoteexe/buildvc.bat
+++ b/tools/ringnotepad/rnoteexe/buildvc.bat
@@ -1,6 +1,7 @@
 echo off
 rem call vc.bat
-call ../../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../../language/src/locatevc.bat auto %1
 
 cls
 
@@ -8,3 +9,4 @@ rc rnote.rc
 cl rnote.c rnote.res /link advapi32.lib shell32.lib /SUBSYSTEM:WINDOWS,"5.01" 
 
 copy rnote.exe ..\..\..\RingNotepad.exe
+endlocal

--- a/tools/ringpm/buildringpm.bat
+++ b/tools/ringpm/buildringpm.bat
@@ -1,3 +1,5 @@
-call ../../language/src/locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ../../language/src/locatevc.bat auto %1
 ring2exe ringpm.ring -static
 move ringpm.exe ..\..\bin\ringpm.exe
+endlocal

--- a/tools/ringrepl/build.bat
+++ b/tools/ringrepl/build.bat
@@ -1,3 +1,5 @@
-call ..\..\language\src\locatevc.bat
+setlocal enableextensions enabledelayedexpansion
+call ..\..\language\src\locatevc.bat auto %1
 ring2exe ringrepl.ring -static
 copy ringrepl.exe ..\..\bin\ringrepl.exe
+endlocal


### PR DESCRIPTION
The `setlocal` change avoids that environment variables are polluted which was causing failure when building a lot of extensions in the same CMD session.
The `locatevc.bat `change fixes an issue when using "auto" as first parameter because running "`RINGEXEPATH`" at line 32 was causing an error in some cases: using `call` avoids this problem and it is more reliable.