### PR TITLE
Update StdLib - Add AppArguments() function

### DIFF
--- a/documents/source/stdlib.txt
+++ b/documents/source/stdlib.txt
@@ -149,6 +149,33 @@ Example:
 	else see "Application is running under Ring interpreter" ok
 
 .. index:: 
+	pair: Stdlib Functions; apparguments()
+
+AppArguments() function
+==================
+
+Get the effective arguments passed to the Ring script
+
+Syntax:
+
+.. code-block:: ring
+
+	AppArguments() ---> The arguments as a list of strings
+
+Example:
+
+.. code-block:: ring
+
+	Load "stdlib.ring"
+
+	# Application Arguments
+	Puts("Test AppArguments()")
+	argsList = AppArguments()
+	argsCount = Len(argsList)
+	if argsCount = 0 see "No arguments passed to the Ring script" + nl
+	else see "Ring script arguments = " + nl + list2str(argsList) + nl ok
+
+.. index:: 
 	pair: Stdlib Functions; apppath()
 
 AppPath() function

--- a/libraries/stdlib/stdlibcore.ring
+++ b/libraries/stdlib/stdlibcore.ring
@@ -140,6 +140,25 @@ Func IsAppCompiled
 	else
 		return true
 	ok
+	
+/*
+	Function Name	: apparguments
+	Usage		: get effective arguments passed to the Ring script 
+	Parameters	: no Parameters
+	Output		: list of strings. Empty list if no arguments passed to the Ring script
+*/
+Func AppArguments
+	argsstartindex = 3 # starting index of arguments in sysargv when interpreted
+	if IsAppCompiled()
+		argsstartindex = 2 # starting index of arguments in sysargv  when compiled
+	ok
+
+	appArgsList = []
+	sysargcount = Len(sysargv)
+	for i=argsstartindex to sysargcount
+		appArgsList + sysargv[i]
+	next
+	return appArgsList
 
 /*
 	Function Name	: apppath


### PR DESCRIPTION
`AppArguments` function returns the effective arguments passed to the Ring script. This is more practical than `sysargv` when we just need the effective arguments specified by the user to the Ring script and not the exe name and script name. Moreover, depending if the Ring script is compiled or not, `sysargv` doesn't have the same format with regards to the position of the effective arguments.