### PR TITLE
Fix bug in handling of binary string by VM stack that caused loss of value

### DIFF
--- a/language/include/ring_vm.h
+++ b/language/include/ring_vm.h
@@ -132,7 +132,7 @@
     #define RING_VM_STACK_PUSHCVAR ring_itemarray_setstring2(pVM->aStack,pVM->nSP,ring_list_getstring(pVar,3),ring_list_getstringsize(pVar,3))
     #define RING_VM_STACK_PUSHNVAR ring_itemarray_setdouble(pVM->aStack,pVM->nSP,ring_list_getdouble(pVar,3))
     #define RING_VM_STACK_PUSHPVALUE(x) pVM->nSP++ ; ring_itemarray_setpointer(pVM->aStack, pVM->nSP , x )
-    #define RING_VM_STACK_PUSHCVALUE(x) pVM->nSP++ ; ring_itemarray_setstring(pVM->aStack, pVM->nSP, x)
+    #define RING_VM_STACK_PUSHCVALUE(x,y) pVM->nSP++ ; ring_itemarray_setstring2(pVM->aStack, pVM->nSP, x, y)
     #define RING_VM_STACK_PUSHNVALUE(x) pVM->nSP++ ; ring_itemarray_setdouble(pVM->aStack, pVM->nSP , x)
     #define RING_VM_STACK_SETCVALUE(x) ring_itemarray_setstring(pVM->aStack, pVM->nSP, x)
     #define RING_VM_STACK_SETNVALUE(x) ring_itemarray_setdouble(pVM->aStack, pVM->nSP , x)

--- a/language/src/ring_vmduprange.c
+++ b/language/src/ring_vmduprange.c
@@ -9,8 +9,8 @@ void ring_vm_dup ( VM *pVM )
     void *pPointer  ;
     int nType  ;
     if ( RING_VM_STACK_ISSTRING ) {
-        pString = ring_string_new_gc(pVM->pRingState,RING_VM_STACK_READC);
-        RING_VM_STACK_PUSHCVALUE(ring_string_get(pString));
+        pString = ring_string_new2_gc(pVM->pRingState,RING_VM_STACK_READC,RING_VM_STACK_STRINGSIZE);
+        RING_VM_STACK_PUSHCVALUE(ring_string_get(pString),ring_string_size(pString));
         ring_string_delete_gc(pVM->pRingState,pString);
     }
     else if ( RING_VM_STACK_ISNUMBER ) {
@@ -54,11 +54,11 @@ void ring_vm_range ( VM *pVM )
         }
     }
     else if ( RING_VM_STACK_ISSTRING ) {
-        pString1 = ring_string_new_gc(pVM->pRingState,RING_VM_STACK_READC);
+        pString1 = ring_string_new2_gc(pVM->pRingState,RING_VM_STACK_READC,RING_VM_STACK_STRINGSIZE);
         RING_VM_STACK_POP ;
         if ( ring_string_size(pString1) == 1 ) {
             if ( RING_VM_STACK_ISSTRING ) {
-                pString2 = ring_string_new_gc(pVM->pRingState,RING_VM_STACK_READC);
+                pString2 = ring_string_new2_gc(pVM->pRingState,RING_VM_STACK_READC,RING_VM_STACK_STRINGSIZE);
                 RING_VM_STACK_POP ;
                 if ( ring_string_size(pString2)  == 1 ) {
                     cStr[1] = '\0' ;

--- a/language/src/ring_vmfuncs.c
+++ b/language/src/ring_vmfuncs.c
@@ -306,7 +306,7 @@ void ring_vm_call2 ( VM *pVM )
         if ( nSP == pVM->nSP ) {
             /* IgnoreNULL is Used by len(object) to get output from operator overloading method */
             if ( pVM->nIgnoreNULL  == 0 ) {
-                RING_VM_STACK_PUSHCVALUE("");
+                RING_VM_STACK_PUSHCVALUE("",0);
             }
             else {
                 pVM->nIgnoreNULL = 0 ;
@@ -424,7 +424,7 @@ void ring_vm_return ( VM *pVM )
 
 void ring_vm_returnnull ( VM *pVM )
 {
-    RING_VM_STACK_PUSHCVALUE("");
+    RING_VM_STACK_PUSHCVALUE("",0);
     ring_vm_return(pVM);
 }
 

--- a/language/src/ring_vmlists.c
+++ b/language/src/ring_vmlists.c
@@ -87,7 +87,7 @@ void ring_vm_listitem ( VM *pVM )
     Item *pItem  ;
     pList = (List *) ring_list_getpointer(pVM->pNestedLists,ring_list_getsize(pVM->pNestedLists));
     if ( RING_VM_STACK_ISSTRING ) {
-        ring_list_addstring_gc(pVM->pRingState,pList, RING_VM_STACK_READC);
+        ring_list_addstring2_gc(pVM->pRingState,pList, RING_VM_STACK_READC,RING_VM_STACK_STRINGSIZE);
         RING_VM_STACK_POP ;
     }
     else if ( RING_VM_STACK_ISNUMBER ) {
@@ -214,7 +214,7 @@ void ring_vm_loadindexaddress ( VM *pVM )
         RING_VM_STACK_OBJTYPE = RING_OBJTYPE_LISTITEM ;
     }
     else if ( RING_VM_STACK_ISSTRING ) {
-        pString = ring_string_new_gc(pVM->pRingState,RING_VM_STACK_READC);
+        pString = ring_string_new2_gc(pVM->pRingState,RING_VM_STACK_READC,RING_VM_STACK_STRINGSIZE);
         RING_VM_STACK_POP ;
         /* Use String to find the item */
         if ( RING_VM_STACK_ISPOINTER ) {

--- a/language/src/ring_vmoop.c
+++ b/language/src/ring_vmoop.c
@@ -951,8 +951,8 @@ void ring_vm_oop_setproperty ( VM *pVM )
         }
         else if ( RING_VM_STACK_ISSTRING ) {
             ring_list_setint_gc(pVM->pRingState,pList2,RING_VAR_TYPE,RING_VM_STRING);
-            ring_list_setstring_gc(pVM->pRingState,pList2,RING_VAR_VALUE,RING_VM_STACK_READC);
-            ring_list_addstring_gc(pVM->pRingState,pList,RING_VM_STACK_READC);
+            ring_list_setstring2_gc(pVM->pRingState,pList2,RING_VAR_VALUE,RING_VM_STACK_READC,RING_VM_STACK_STRINGSIZE);
+            ring_list_addstring2_gc(pVM->pRingState,pList,RING_VM_STACK_READC,RING_VM_STACK_STRINGSIZE);
         }
         else if ( RING_VM_STACK_ISPOINTER ) {
             ring_list_setint_gc(pVM->pRingState,pList2,RING_VAR_TYPE,RING_VM_POINTER);
@@ -1012,7 +1012,7 @@ void ring_vm_oop_setproperty ( VM *pVM )
                 RING_VM_STACK_PUSHNVALUE(ring_list_getdouble(pList,6));
             }
             else if ( ring_list_isstring(pList,6) ) {
-                RING_VM_STACK_PUSHCVALUE(ring_list_getstring(pList,6));
+                RING_VM_STACK_PUSHCVALUE(ring_list_getstring(pList,6), ring_list_getstringsize(pList,6));
             }
             else if ( ring_list_ispointer(pList,6) ) {
                 RING_VM_STACK_PUSHPVALUE(ring_list_getpointer(pList,6));

--- a/language/src/ring_vmstackvars.c
+++ b/language/src/ring_vmstackvars.c
@@ -10,7 +10,7 @@ void ring_vm_pushv ( VM *pVM )
         **  Happens after using EVAL() in this case we avoid PUSHV 
         **  Add Output Value (if Eval() parameter (Code to be executed) miss the Return <Expr> command) 
         */
-        RING_VM_STACK_PUSHCVALUE("") ;
+        RING_VM_STACK_PUSHCVALUE("",0) ;
         return ;
     }
     switch ( RING_VM_STACK_OBJTYPE ) {

--- a/language/src/ring_vmstate.c
+++ b/language/src/ring_vmstate.c
@@ -497,7 +497,7 @@ List * ring_vm_savestack ( VM *pVM )
     pList = ring_list_new_gc(pVM->pRingState,0);
     while ( pVM->nSP  != 0 ) {
         if ( RING_VM_STACK_ISSTRING ) {
-            ring_list_addstring_gc(pVM->pRingState,pList,RING_VM_STACK_READC);
+            ring_list_addstring2_gc(pVM->pRingState,pList,RING_VM_STACK_READC,RING_VM_STACK_STRINGSIZE);
         }
         else if ( RING_VM_STACK_ISNUMBER ) {
             ring_list_adddouble_gc(pVM->pRingState,pList,RING_VM_STACK_READN);
@@ -523,7 +523,7 @@ void ring_vm_restorestack ( VM *pVM,List *pList )
     }
     for ( x = ring_list_getsize(pList) ; x >= 1 ; x-- ) {
         if ( ring_list_isstring(pList,x) ) {
-            RING_VM_STACK_PUSHCVALUE(ring_list_getstring(pList,x));
+            RING_VM_STACK_PUSHCVALUE(ring_list_getstring(pList,x),ring_list_getstringsize(pList,x));
         }
         else if ( ring_list_isnumber(pList,x) ) {
             RING_VM_STACK_PUSHNVALUE(ring_list_getdouble(pList,x));

--- a/language/src/ring_vmstrindex.c
+++ b/language/src/ring_vmstrindex.c
@@ -22,7 +22,7 @@ void ring_vm_string_assignment ( VM *pVM )
     String *cStr1  ;
     char *newstr  ;
     if ( RING_VM_STACK_ISSTRING ) {
-        cStr1 = ring_string_new_gc(pVM->pRingState,RING_VM_STACK_READC);
+        cStr1 = ring_string_new2_gc(pVM->pRingState,RING_VM_STACK_READC,RING_VM_STACK_STRINGSIZE);
         RING_VM_STACK_POP ;
         if ( ring_string_size(cStr1) == 1 ) {
             newstr = (char *) RING_VM_STACK_READP ;


### PR DESCRIPTION
The VM stack handling of string values supposes that they are simple text string that are null terminated and this caused string values holding binary data to lose correct value under various circumstances.
For example, the following code produce incorrect result:
```
keyValue = hex2str("0011223344556677")
key = [:name="key", :value=keyValue]
See "keyValue length = " + Len(keyValue) + nl
See "key.value length = " + Len(key[:value]) + nl

if keyValue = key[:value] See "Test OK" + nl else See "Test Failed!!" + nl ok
```
Its output is:
```
keyValue length = 8
key.value length = 0
Test Failed!!
```

As we can see, we lost `keyValue` content once it was copied into the list `key`.

This commit fixes this by changing the code to use `ring_itemarray_setstring2`, `ring_string_new2_gc`, `ring_list_addstring2_gc` and  `ring_list_setstring2_gc` at places not requiring text strings in order to not loose information about the real size of the string and to avoid the use of `strlen` function on binary strings.
At functionality level, there is no change since using the real size with text strings when copying them will keep the position of the zero terminating characters and so strlen/strcmp and related functions will behave the same.