### PR TITLE
Remove unnecessary String allocation in ring_vm_range and ring_vm_string_assignment

### DIFF
--- a/language/src/ring_vmduprange.c
+++ b/language/src/ring_vmduprange.c
@@ -28,9 +28,8 @@ void ring_vm_dup ( VM *pVM )
 void ring_vm_range ( VM *pVM )
 {
     double nNum1,nNum2  ;
-    int x  ;
+    int x,nSize1,nSize2  ;
     char cStr[2]  ;
-    String *pString1,*pString2  ;
     List *pVar  ;
     if ( RING_VM_STACK_ISNUMBER ) {
         nNum1 = RING_VM_STACK_READN ;
@@ -54,16 +53,20 @@ void ring_vm_range ( VM *pVM )
         }
     }
     else if ( RING_VM_STACK_ISSTRING ) {
-        pString1 = ring_string_new2_gc(pVM->pRingState,RING_VM_STACK_READC,RING_VM_STACK_STRINGSIZE);
+		nSize1 = RING_VM_STACK_STRINGSIZE;
+		if ( nSize1 == 1) {
+			nNum1 = RING_VM_STACK_READC[0] ;
+		}
         RING_VM_STACK_POP ;
-        if ( ring_string_size(pString1) == 1 ) {
+        if ( nSize1 == 1 ) {
             if ( RING_VM_STACK_ISSTRING ) {
-                pString2 = ring_string_new2_gc(pVM->pRingState,RING_VM_STACK_READC,RING_VM_STACK_STRINGSIZE);
+				nSize2 = RING_VM_STACK_STRINGSIZE;
+				if ( nSize2 == 1) {
+					nNum2 = RING_VM_STACK_READC[0] ;
+				}
                 RING_VM_STACK_POP ;
-                if ( ring_string_size(pString2)  == 1 ) {
+                if ( nSize2 == 1 ) {
                     cStr[1] = '\0' ;
-                    nNum1 = pString1->cStr[0] ;
-                    nNum2 = pString2->cStr[0] ;
                     /* Create List Variable */
                     pVar = ring_vm_range_newlist(pVM);
                     /* Create List */
@@ -80,10 +83,8 @@ void ring_vm_range ( VM *pVM )
                         }
                     }
                 }
-                ring_string_delete_gc(pVM->pRingState,pString2);
             }
         }
-        ring_string_delete_gc(pVM->pRingState,pString1);
     }
 }
 

--- a/language/src/ring_vmstrindex.c
+++ b/language/src/ring_vmstrindex.c
@@ -19,20 +19,22 @@ void ring_vm_string_pushv ( VM *pVM )
 
 void ring_vm_string_assignment ( VM *pVM )
 {
-    String *cStr1  ;
     char *newstr  ;
+	char cChar ;
+	int nSize ;
     if ( RING_VM_STACK_ISSTRING ) {
-        cStr1 = ring_string_new2_gc(pVM->pRingState,RING_VM_STACK_READC,RING_VM_STACK_STRINGSIZE);
+		nSize = RING_VM_STACK_STRINGSIZE;
+		if ( nSize == 1 ) {
+			cChar = RING_VM_STACK_READC[0];
+		}
         RING_VM_STACK_POP ;
-        if ( ring_string_size(cStr1) == 1 ) {
+        if ( nSize == 1 ) {
             newstr = (char *) RING_VM_STACK_READP ;
             RING_VM_STACK_POP ;
-            newstr[0] = ring_string_get(cStr1)[0] ;
-            ring_string_delete_gc(pVM->pRingState,cStr1);
+            newstr[0] = cChar ;
             return ;
         }
         else {
-            ring_string_delete_gc(pVM->pRingState,cStr1);
             ring_vm_error(pVM,RING_VM_ERROR_VALUEMORETHANONECHAR);
             return ;
         }


### PR DESCRIPTION
In `ring_vm_range`, we can get the size and first character of each string beforehand and so no string copy is needed.
In `ring_vm_string_assignment`, we can get the size and first character of the string beforehand and so no string copy is needed.