### PR TITLE
Fix bug in NotEqual operator when used with strings

### DIFF
--- a/language/src/ring_vmexpr.c
+++ b/language/src/ring_vmexpr.c
@@ -565,7 +565,7 @@ void ring_vm_notequal ( VM *pVM )
         if ( RING_VM_STACK_ISSTRING ) {
             cStr2 = RING_VM_STACK_GETSTRINGRAW ;
             /* Compare */
-            if ( strcmp(ring_string_get(cStr1),ring_string_get(cStr2)) == 0 ) {
+            if ( (ring_string_size(cStr1) == ring_string_size(cStr2)) && (memcmp(ring_string_get(cStr1), ring_string_get(cStr2), ring_string_size(cStr1)) == 0) ) {
                 RING_VM_STACK_FALSE ;
             }
             else {


### PR DESCRIPTION
`!=` operator returns wrong result when used with strings containing binary data.
The following Ring code reproduces the issue

```
value1 = hex2str("3ad70001")
value2 = hex2str("3ad7000198A4E841")

if value1 != value2
	See "Test OK" + nl
else
	See "Test FAILED!!" + nl
ok
```

