### PR TITLE
RingOpenSSL: fix openssl 1.1.1 compatibility by initializing it correctly and using adequate AES-XTS test vector that doesn't use duplicated keys

### DIFF
--- a/extensions/ringopenssl/ring_vmopenssl.c
+++ b/extensions/ringopenssl/ring_vmopenssl.c
@@ -57,6 +57,9 @@ RING_LIBINIT
 	/* Ref: https://wiki.openssl.org/index.php/Library_Initialization */
 	#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	OpenSSL_add_all_algorithms();
+    #else
+    /* Ref: https://www.openssl.org/docs/man1.1.1/man3/OPENSSL_init_crypto.html */
+    OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
 	#endif
 }
 


### PR DESCRIPTION
OpenSSL 1.1.1 rejects duplicated XTS keys, so we ensure that our test vectors follow this:
https://github.com/openssl/openssl/blob/c39352/crypto/evp/e_aes.c#L3119

Also, we need to call `OPENSSL_init_crypto` explicitly to make OpenSSL populate internal list of algorithms.