### PR TITLE
RingOpenSSL: first implementation of RSA support (key generation,import,export,encryption,decryption)

### DIFF
--- a/documents/source/secfunc.txt
+++ b/documents/source/secfunc.txt
@@ -25,6 +25,18 @@ Before using the next functions load the openssllib.ring library
 * Encrypt()
 * Decrypt()
 * Randbytes()
+* rsa_generate
+* rsa_export_params
+* rsa_import_params
+* rsa_export_pem
+* rsa_import_pem
+* rsa_is_privatekey
+* rsa_encrypt_pkcs
+* rsa_decrypt_pkcs
+* rsa_encrypt_oaep
+* rsa_decrypt_oaep
+* openssl_versiontext
+* openssl_version
 * MD5Init(), MD5Update(), MD5Final()
 * SHA1Init(), SHA1Update(), SHA1Final()
 * SHA256Init(), SHA256Update(), SHA256Final()
@@ -397,6 +409,517 @@ Example:
 	password = "SecretPassWord@$%123"
 	see salt + nl
 	see sha256("test" + salt) + nl
+
+
+.. index:: 
+	pair: Security and Internet Functions; rsa_generate()
+
+rsa_generate() Function
+====================
+
+We can generate a random RSA key pair using the rsa_generate() function.
+
+Syntax:
+
+.. code-block:: ring
+
+	rsa_generate(nBits[,nPublicExponent]) ---> a random RSA key pair with nBits as size in bits
+			If nPublicExponent is omited, then the standard public exponent value 65537 is used.
+
+Example:
+
+.. code-block:: ring
+
+	/* generate a new 2048-bit RSA key pair */
+	try
+		rsaKey = rsa_generate(2048)
+		rsaKeyParams = rsa_export_params(rsaKey)
+		See "Modulus = " + rsaKeyParams[:n] + nl
+	catch
+		See "Failed to generate the RSA key pair: " + cCatchError + nl
+	done
+
+
+.. index:: 
+	pair: Security and Internet Functions; rsa_export_params()
+
+rsa_export_params() Function
+====================
+
+We can export the parameters of an RSA key to a string-indexed list using the rsa_export_params() function.
+The list contains the following string indexes:
+ - "type" for the key type as a string equal to "RSA" in our case
+ - "bits" for the bot length of the key as an integer
+ - "n" for the Modulus as a hexadecimal string
+ - "e" for the Public Exponent as a hexadecimal string
+ - "d" for the Private Exponent as a hexadecimal string
+ - "p" for the first prime as a hexadecimal string
+ - "q" for the second prime as a hexadecimal string
+ - "dmp1" for the first CRT exponent as a hexadecimal string
+ - "dmq1" for the second CRT exponent as a hexadecimal string
+ - "iqmp" for the CRT coefficent as a hexadecimal string
+
+If the key contains only the public part, then "d", "p", "q", "dmp1", "dmq1" and "iqmp" will be empty strings.
+
+Syntax:
+
+.. code-block:: ring
+
+	rsa_export_params(pRsaKey) ---> list of the key parameters
+
+Example:
+
+.. code-block:: ring
+
+	/* generate a new 2048-bit RSA key pair */
+	try
+		rsaKey = rsa_generate(2048)
+		rsaKeyParams = rsa_export_params(rsaKey)
+		See "Key Type = " + rsaKeyParams[:type] + nl
+		See "Key Size = " + rsaKeyParams[:bits] + " bits" + nl
+		See "Modulus = " + rsaKeyParams[:n] + nl
+		See "Public Exponent = " + rsaKeyParams[:e] + nl
+		See "Private Exponent = " + rsaKeyParams[:d] + nl
+		See "Prime 1 = " + rsaKeyParams[:p] + nl
+		See "Prime 2 = " + rsaKeyParams[:q] + nl
+		See "CRT Exponent 1 = " + rsaKeyParams[:dmp1] + nl
+		See "CRT Exponent 2 = " + rsaKeyParams[:dmq1] + nl
+		See "CRT Coefficient = " + rsaKeyParams[:iqmp] + nl
+	catch
+		See "Failed to generate the RSA key pair: " + cCatchError + nl
+	done
+
+
+.. index:: 
+	pair: Security and Internet Functions; rsa_import_params()
+
+rsa_import_params() Function
+====================
+
+We can create a new RSA key from parameters stored in a string-indexed list using the rsa_import_params() function.
+The format of the input list is the one described in the function rsa_export_params
+
+The indexes "n" and "e" must not be empty, otherwise an exception is thrown.
+If we need to import only an RSA public key, then the indexes "d", "p", "q", "dmp1", "dmq1" and "iqmp" must be empty.
+
+Syntax:
+
+.. code-block:: ring
+
+	rsa_import_params(pParamsList) ---> a new RSA key
+
+Example:
+
+.. code-block:: ring
+
+	/* create an RSA public key from a generated RSA key pair */
+	try
+		rsaKey = rsa_generate(2048)
+		rsaKeyParams = rsa_export_params(rsaKey)
+
+		/* create parameters of public key: modulus and public exponent */
+		rsaPublicKeyParam = [:n = rsaKeyParams[:n], :e = rsaKeyParams[:e]]
+		/* create the public key using rsa_import_params */
+		rsaPublicKey = rsa_import_params(rsaPublicKeyParam)
+
+	catch
+		See "Unexpected error occured: " + cCatchError + nl
+	done
+
+
+.. index:: 
+	pair: Security and Internet Functions; rsa_export_pem()
+
+rsa_export_pem() Function
+====================
+
+We can export an RSA key to a string in PEM format using the rsa_export_pem() function.
+If the RSA key contains both public and private parts, then returned string  will start with "-----BEGIN PRIVATE KEY-----"
+If the RSA key contains only the public part, then returned string will start with "-----BEGIN PUBLIC KEY-----"
+
+Syntax:
+
+.. code-block:: ring
+
+	rsa_export_pem(pRsaKey) ---> string encoding of the key in PEM format
+
+Example:
+
+.. code-block:: ring
+
+	/* generate an RSA key and save it to a file in PEM format */
+	try
+		rsaKey = rsa_generate(2048)
+		rsaKeyPEM = rsa_export_pem(rsaKey)
+		/* save private key to a file */
+		write ("privateKey.pem", rsaKeyPEM)
+		
+		/* save public key to a file */
+		rsaKeyParams = rsa_export_params(rsaKey)
+		rsaPublicKeyParam = [:n = rsaKeyParams[:n], :e = rsaKeyParams[:e]]
+		rsaPublicKey = rsa_import_params(rsaPublicKeyParam)
+		rsaPublicKeyPEM = rsa_export_pem(rsaPublicKey)
+		write ("publicKey.pem", rsaPublicKeyPEM)
+
+	catch
+		See "Unexpected error occured: " + cCatchError + nl
+	done
+
+
+.. index:: 
+	pair: Security and Internet Functions; rsa_import_pem()
+
+rsa_import_pem() Function
+====================
+
+We can create an RSA key from PEM encoded string using the rsa_import_pem() function.
+If the PEM string starts with "-----BEGIN PRIVATE KEY-----", then a full RSA key pair will be created.
+if the PEM string starts with "-----BEGIN PUBLIC KEY-----", then an RSA public key will be created.
+
+Syntax:
+
+.. code-block:: ring
+
+	rsa_import_pem(cStrPEM) ---> a new RSA key
+
+Example:
+
+.. code-block:: ring
+
+	/* create an RSA key from a PEM file */
+	try
+		rsaKeyPEM = Read("privateKey.pem")
+		rsaKey = rsa_import_pem(rsaKeyPEM)
+		
+		rsaPublicKeyPEM = Read("publicKey.pem")
+		rsaPublicKey = rsa_import_pem(rsaPublicKeyPEM)
+	catch
+		See "Unexpected error occured: " + cCatchError + nl
+	done
+
+
+.. index:: 
+	pair: Security and Internet Functions; rsa_is_privatekey()
+
+rsa_is_privatekey() Function
+====================
+
+We can check whether an RSA key is a private key or public key using the rsa_is_privatekey() function.
+
+Syntax:
+
+.. code-block:: ring
+
+	rsa_is_privatekey(pRsaKey) ---> returns 1 if pRsaKey is an RSA private key and 0 if it is an RSA public key
+
+Example:
+
+.. code-block:: ring
+
+	/* create an RSA key from a PEM file and check if it is a private key */
+	try
+		rsaKeyPEM = Read("key.pem")
+		rsaKey = rsa_import_pem(rsaKeyPEM)
+		
+		if rsa_is_privatekey(rsaKey)
+			See "an RSA private key was loaded" + nl
+		else
+			See "an RSA public key was loaded" + nl
+		ok
+	catch
+		See "Unexpected error occured: " + cCatchError + nl
+	done
+
+
+.. index:: 
+	pair: Security and Internet Functions; rsa_encrypt_pkcs()
+
+rsa_encrypt_pkcs() Function
+====================
+
+We can encrypt data with an RSA key and PKCS#1 v1.5 padding using the rsa_encrypt_pkcs() function.
+The maximum size of data that can be encrypted by rsa_encrypt_pkcs is (modulusLen - 11), with modulusLen
+the length of the RSA key modulus is bytes.
+For example, for 2048-bit RSA key, the length of modulus is 2048/8 = 256 bytes and so the maximum size
+of data that can be encrypted is 256 - 11 = 245 bytes.
+RSA encryption is usually applied to a symmetric key (e.g. AES) which is used to encrypt much larger data.
+RSA encryption needs only the public part of an RSA key, so rsa_encrypt_pkcs can be used with both RSA private
+key and RSA public key
+
+Syntax:
+
+.. code-block:: ring
+
+	rsa_encrypt_pkcs(pRsaKey,cPlainData) ---> return a string containing the encryption of cPlainData
+
+Example:
+
+.. code-block:: ring
+
+	/* encrypt a file using AES key and then encrypt the AES key using an RSA public key */
+	try
+		/* read Alice public key */
+		rsaPublicKeyPEM = Read("alice_public_key.pem")
+		rsaPublicKey = rsa_import_pem(rsaPublicKeyPEM)
+		
+		/* encrypt file with random AES-128 key */
+		cData = Read ("secret_document.txt")
+		cKey = RandBytes(16)
+		cIV = RandBytes(16)
+		cEncryptedData = Encrypt(cData,cKey,cIV,"aes128") 
+		
+		/* encrypt the AES-128 key with the RSA public key */
+		cEncryptedKey = rsa_encrypt_pkcs(rsaPublicKey,cKey)
+		
+		/* store IV, encrypted AES key and encrypted data in a file to be sent to Alice*/
+		Write("encrypted_document.enc", cIV + cEncryptedKey + cEncryptedData)
+		
+	catch
+		See "Unexpected error occured: " + cCatchError + nl
+	done
+
+
+.. index:: 
+	pair: Security and Internet Functions; rsa_decrypt_pkcs()
+
+rsa_decrypt_pkcs() Function
+====================
+
+We can decrypt data encrypted with an RSA key and PKCS#1 v1.5 padding using the rsa_decrypt_pkcs() function.
+The size of data that can be decrypted by rsa_decrypt_pkcs must be equal to modulusLen which is the length 
+of the RSA key modulus is bytes.
+For example, for 2048-bit RSA key, the length of modulus is 2048/8 = 256 bytes and so the size of encrypted data 
+that can be decrypted must be 256 bytes.
+For RSA decryption, the RSA key must contain the private key part.
+
+Syntax:
+
+.. code-block:: ring
+
+	rsa_decrypt_pkcs(pRsaKey,cEncryptedData) ---> return a string containing the decryption of cEncryptedData
+
+Example:
+
+.. code-block:: ring
+
+	/* decrypt a file by first decrypting AES key that was used to encrypt it 
+	 * and then decrypt the whole content using the AES key
+	 */
+	try
+		/* read Alice private key */
+		rsaKeyPEM = Read("alice_private_key.pem")
+		rsaKey = rsa_import_pem(rsaKeyPEM)
+		
+		/* calculate the modulus length */
+		rsaKeyParams = rsa_export_params(rsaKey)
+		modulusLen = rsaKeyParams[:bits]/ 8
+		
+		/* read encrypted file */
+		cEncryptedContent = Read ("encrypted_document.enc")
+		
+		/* IV is the first 16 bytes if the file */
+		cIV = substr(cEncryptedContent, 1, 16)
+		
+		/* encrypted key follows IV and its length is modulusLen */
+		cEncryptedKey = substr(cEncryptedContent, 17, modulusLen)
+		
+		/* encrypted data follows the key */
+		cEncryptedData = substr(cEncryptedContent, 17 + modulusLen)
+		
+		/* decrypt the AES-128 key */
+		cKey = rsa_decrypt_pkcs(rsaKey,cEncryptedKey)
+		
+		/* decrypt the data using the AES-128 key */
+		
+		cPlainData = Decrypt(cEncryptedData,cKey,cIV,"aes128") 
+
+		/* store the decrypted data to a file */
+		Write("decrypted_document.txt", cPlainData)
+		
+	catch
+		See "Unexpected error occured: " + cCatchError + nl
+	done
+
+
+.. index:: 
+	pair: Security and Internet Functions; rsa_encrypt_oaep()
+
+rsa_encrypt_oaep() Function
+====================
+
+We can encrypt data with an RSA key and OAEP padding using the rsa_encrypt_oaep() function.
+The maximum size of data that can be encrypted by rsa_encrypt_oaep is (modulusLen - 2*hashLen -2), 
+with modulusLen the length of the RSA key modulus is bytes and hashLen and the length of hash algorithm used.
+For example, for 2048-bit RSA key, the length of modulus is 2048/8 = 256 bytes and so the maximum size
+of data that can be encrypted using OAEP padding with SHA-1 is 256 - 2*20 - 2 = 214 bytes.
+RSA encryption is usually applied to a symmetric key (e.g. AES) which is used to encrypt much larger data.
+RSA encryption needs only the public part of an RSA key, so rsa_encrypt_oaep can be used with both RSA private
+key and RSA public key.
+
+Syntax:
+
+.. code-block:: ring
+
+	rsa_encrypt_oaep(pRsaKey,cPlainData[,nHashAlgorithm]) ---> return a string containing the OAEP encryption of cPlainData
+		nHashAlgorithm indicates the hash algorithm to use for OAEP padding. If omited, SHA-1 is used by default.
+		Possible values for nHashAlgorithm argument are:
+		 - $OSSL_HASH_MD5 which is equal to 0
+		 - $OSSL_HASH_SHA1 which is equal to 1
+		 - $OSSL_HASH_SHA256 which is equal to 2
+		 - $OSSL_HASH_SHA384 which is equal to 3
+		 - $OSSL_HASH_SHA512 which is equal to 4
+
+Example:
+
+.. code-block:: ring
+
+	/* encrypt a file using AES key and then encrypt the AES key using an RSA public key using OAEP padding */
+	try
+		/* read Alice public key */
+		rsaPublicKeyPEM = Read("alice_public_key.pem")
+		rsaPublicKey = rsa_import_pem(rsaPublicKeyPEM)
+		
+		/* encrypt file with random AES-128 key */
+		cData = Read ("secret_document.txt")
+		cKey = RandBytes(16)
+		cIV = RandBytes(16)
+		cEncryptedData = Encrypt(cData,cKey,cIV,"aes128") 
+		
+		/* encrypt the AES-128 key with the RSA public key */
+		cEncryptedKey = rsa_encrypt_oaep(rsaPublicKey,cKey)
+		
+		/* store IV, encrypted AES key and encrypted data in a file to be sent to Alice*/
+		Write("oaep_encrypted_document.enc", cIV + cEncryptedKey + cEncryptedData)
+		
+	catch
+		See "Unexpected error occured: " + cCatchError + nl
+	done
+
+
+.. index:: 
+	pair: Security and Internet Functions; rsa_decrypt_oaep()
+
+rsa_decrypt_oaep() Function
+====================
+
+We can decrypt data encrypted with an RSA key and OAEP padding using the rsa_decrypt_oaep() function.
+The size of data that can be decrypted by rsa_decrypt_oaep must be equal to modulusLen which is the length 
+of the RSA key modulus is bytes.
+For example, for 2048-bit RSA key, the length of modulus is 2048/8 = 256 bytes and so the size of encrypted data 
+that can be decrypted must be 256 bytes.
+For RSA decryption, the RSA key must contain the private key part.
+The hash algorithm specified in rsa_decrypt_oaep() call must be the same as the one used during OAEP encryption.
+
+Syntax:
+
+.. code-block:: ring
+
+	rsa_decrypt_oaep(pRsaKey,cEncryptedData[,nHashAlgorithm]) ---> return a string containing the decryption of cEncryptedData
+		nHashAlgorithm indicates the hash algorithm to use for OAEP padding. If omited, SHA-1 is used by default.
+		Possible values for nHashAlgorithm argument are:
+		 - $OSSL_HASH_MD5 which is equal to 0
+		 - $OSSL_HASH_SHA1 which is equal to 1
+		 - $OSSL_HASH_SHA256 which is equal to 2
+		 - $OSSL_HASH_SHA384 which is equal to 3
+		 - $OSSL_HASH_SHA512 which is equal to 4
+
+Example:
+
+.. code-block:: ring
+
+	/* decrypt a file by first decrypting AES key that was used to encrypt it 
+	 * and then decrypt the whole content using the AES key
+	 */
+	try
+		/* read Alice private key */
+		rsaKeyPEM = Read("alice_private_key.pem")
+		rsaKey = rsa_import_pem(rsaKeyPEM)
+		
+		/* calculate the modulus length */
+		rsaKeyParams = rsa_export_params(rsaKey)
+		modulusLen = rsaKeyParams[:bits]/ 8
+		
+		/* read encrypted file */
+		cEncryptedContent = Read ("oaep_encrypted_document.enc")
+		
+		/* IV is the first 16 bytes if the file */
+		cIV = substr(cEncryptedContent, 1, 16)
+		
+		/* encrypted key follows IV and its length is modulusLen */
+		cEncryptedKey = substr(cEncryptedContent, 17, modulusLen)
+		
+		/* encrypted data follows the key */
+		cEncryptedData = substr(cEncryptedContent, 17 + modulusLen)
+		
+		/* decrypt the AES-128 key */
+		cKey = rsa_decrypt_oaep(rsaKey,cEncryptedKey)
+		
+		/* decrypt the data using the AES-128 key */
+		
+		cPlainData = Decrypt(cEncryptedData,cKey,cIV,"aes128") 
+
+		/* store the decrypted data to a file */
+		Write("oaep_decrypted_document.txt", cPlainData)
+		
+	catch
+		See "Unexpected error occured: " + cCatchError + nl
+	done
+
+
+.. index:: 
+	pair: Security and Internet Functions; openssl_versiontext()
+
+openssl_versiontext() Function
+====================
+
+We can get the full version text of the OpenSSL library using the function openssl_versiontext().
+The returned string is equal to the value returned by the command "openssl.exe version"
+
+Syntax:
+
+.. code-block:: ring
+
+	openssl_versiontext() ---> return a string containing the full version text of OpenSSL library
+
+Example:
+
+.. code-block:: ring
+
+	/* Display the version of OpenSSL library used by Ring
+	 */
+	See "Ring is using " + openssl_versionText() + nl
+
+
+.. index:: 
+	pair: Security and Internet Functions; openssl_version()
+
+openssl_version() Function
+====================
+
+We can get the version numbers (Major,Minor,Fix) of the OpenSSL library using the function openssl_version().
+The returned list contains three items corresponding to the the three part of the version.
+For example, for OpenSSL 1.0.2, openssl_version() returns the list [1,0,2]
+
+Syntax:
+
+.. code-block:: ring
+
+	openssl_version() ---> return a list containing the version numbers of the OpenSSL library
+		First list item holds the version major number
+		Second list item holds the version minor number
+		Third list item holds the version fix number
+
+Example:
+
+.. code-block:: ring
+
+	/* Display the version number of OpenSSL library used by Ring
+	 */
+	ver = openssl_version()
+	OpenSSLVersionMajor = ver[1] 
+	OpenSSLVersionMinor = ver[2] 
+	OpenSSLVersionFix = ver[3] 
+	See "Ring is using OpenSSL version " + OpenSSLVersionMajor + "." + OpenSSLVersionMinor + "." + OpenSSLVersionFix + nl
 
 
 .. index:: 

--- a/extensions/ringopenssl/openssl_rsa.c
+++ b/extensions/ringopenssl/openssl_rsa.c
@@ -1,0 +1,1003 @@
+/* Version OpenSSL 0.9.8 and Later */
+
+/* implementation of RSA functions
+ * Author: Mounir IDRASSI (mounir@idrix.fr)
+ * First version: April 23rd 2022
+ */
+ 
+static void ring_vm_openssl_pkeyfree( void *pRingState,void *pPointer )
+{
+    EVP_PKEY *pKey  ;
+    pKey = (EVP_PKEY *) pPointer ;
+    EVP_PKEY_free( pKey ) ;
+}
+
+void ring_vm_openssl_rsa_generate ( void *pPointer )
+{
+	EVP_PKEY *pKey ;
+	BIGNUM *e ;
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	EVP_PKEY_CTX *ctx;
+	#else
+	RSA *pRsa  ;
+	#endif
+	int nBits, nPubExp=65537;/* we use 65537 as default exponent */
+	if ( RING_API_PARACOUNT != 1 && RING_API_PARACOUNT != 2) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	if ( ! RING_API_ISNUMBER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	nBits = (int) RING_API_GETNUMBER(1) ;
+	
+	if (nBits < 512 || nBits > OPENSSL_RSA_MAX_MODULUS_BITS) {
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+		return ;
+	}
+	
+	if ( RING_API_PARACOUNT == 2 ) {
+		if ( ! RING_API_ISNUMBER(2) ) {
+			RING_API_ERROR(RING_API_BADPARATYPE);
+			return ;
+		}
+		
+		nPubExp = (int) RING_API_GETNUMBER(2) ;
+		
+		if (nPubExp < 3) {
+			RING_API_ERROR(RING_API_BADPARAVALUE);
+			return ;
+		}
+	}
+	
+	e = BN_new();
+	BN_set_word (e,nPubExp);
+	pKey = NULL;
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+	if (ctx) {
+		if ( (EVP_PKEY_keygen_init(ctx) > 0) 
+			&& (EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, nBits) > 0) 
+			&& (EVP_PKEY_CTX_set_rsa_keygen_pubexp(ctx, e) > 0) ) {
+            /* e belongs now to ctx so we should not free it */
+            e = NULL;
+			/* perform RSA key generation */
+			if (EVP_PKEY_keygen(ctx, &pKey) <= 0) {
+				/* failure */
+				pKey = NULL;
+			}
+		}
+		
+		EVP_PKEY_CTX_free(ctx);
+	}
+	#else
+	pRsa = RSA_new() ;
+	if (RSA_generate_key_ex(pRsa,nBits,e,NULL)) {
+		pKey = EVP_PKEY_new();
+		EVP_PKEY_assign_RSA(pKey, pRsa); /* pRsa is now owned by pKey */
+	}
+	else {
+		RSA_free(pRsa);
+	}
+	#endif
+	
+	if (pKey) {
+		/* success case: return the object */
+		RING_API_RETMANAGEDCPOINTER(pKey,"OSSL_PKEY",ring_vm_openssl_pkeyfree);
+	}
+	else {
+		RING_API_ERROR(RING_API_INTERNALFAILURE);
+	}
+	if (e) {
+        BN_free(e);
+    }
+}
+
+void ring_vm_openssl_rsa_is_privatekey ( void *pPointer )
+{
+	EVP_PKEY *pKey = NULL;
+	RSA *pRsa  ;
+	const BIGNUM *p,*q,*dmp1,*dmq1,*iqmp,*n,*e,*d;
+	List *pList  ;
+	int nSize, nBits;
+	unsigned char* pBuf;
+	if ( RING_API_PARACOUNT != 1 ) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	pKey = (EVP_PKEY*) RING_API_GETCPOINTER(1,"OSSL_PKEY");
+	if ( pKey == NULL) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	/* check that this is indeed an RSA key */
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	if (EVP_PKEY_base_id(pKey) != EVP_PKEY_RSA) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	#else
+	if (EVP_PKEY_type(pKey->type) != EVP_PKEY_RSA) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	#endif
+	
+	pRsa = EVP_PKEY_get1_RSA(pKey);
+	
+	/* export all parameters */
+	#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	n = RSA_get0_n(pRsa);
+	e = RSA_get0_e(pRsa);
+	d = RSA_get0_d(pRsa);
+	p = RSA_get0_p(pRsa);
+	q = RSA_get0_q(pRsa);
+	dmp1 = RSA_get0_dmp1(pRsa);
+	dmq1 = RSA_get0_dmq1(pRsa);
+	iqmp = RSA_get0_iqmp(pRsa);
+	#else
+	n = pRsa->n;
+	e = pRsa->e;
+	d = pRsa->d;
+	p = pRsa->p;
+	q = pRsa->q;
+	dmp1 = pRsa->dmp1;
+	dmq1 = pRsa->dmq1;
+	iqmp = pRsa->iqmp;
+	#endif
+	
+	if (!n || !e) {
+		/* modulus and public exponent must always be present */
+		RING_API_ERROR(RING_API_BADPARATYPE);
+	}
+	else if (d || (p && q && dmp1 && dmq1 && iqmp)) {
+		/* this is private key */
+		RING_API_RETNUMBER(1);
+	}
+	else {
+		/* this is a public key */
+		RING_API_RETNUMBER(0);
+	}
+
+	RSA_free(pRsa);
+}
+
+static void ring_vm_openssl_add_bignum_to_list( void *pPointer, const char* cComponentName, const BIGNUM* pComponent, List* pList, unsigned char* pBuf )
+{
+	char* cStr;
+	List* pSubList;
+	
+	pSubList = ring_list_newlist_gc(((VM *) pPointer)->pRingState,pList);
+	/* first add component name, then add component value */
+	ring_list_addstring_gc(((VM *) pPointer)->pRingState,pSubList,cComponentName);
+	if (pComponent) {
+		cStr = BN_bn2hex(pComponent);
+		ring_list_addstring_gc(((VM *) pPointer)->pRingState,pSubList,cStr);
+	}
+	else {
+		/* add empty string */
+		ring_list_addstring_gc(((VM *) pPointer)->pRingState,pSubList,"");
+	}
+}
+
+static void ring_vm_openssl_add_bits_to_list( void *pPointer, int nBits, List* pList )
+{
+	int nSize;
+	List* pSubList;
+	
+	pSubList = ring_list_newlist_gc(((VM *) pPointer)->pRingState,pList);
+	/* first add component name, then add component value */
+	ring_list_addstring_gc(((VM *) pPointer)->pRingState,pSubList,"bits");
+	ring_list_adddouble_gc(((VM *) pPointer)->pRingState,pSubList, (double) nBits);
+}
+
+static void ring_vm_openssl_add_keytype_to_list( void *pPointer, const char* cKeyType, List* pList )
+{
+	int nSize;
+	List* pSubList;
+	
+	pSubList = ring_list_newlist_gc(((VM *) pPointer)->pRingState,pList);
+	/* first add component name, then add component value */
+	ring_list_addstring_gc(((VM *) pPointer)->pRingState,pSubList,"type");
+	ring_list_addstring_gc(((VM *) pPointer)->pRingState,pSubList,cKeyType);
+}
+
+void ring_vm_openssl_rsa_export_params ( void *pPointer )
+{
+	EVP_PKEY *pKey = NULL;
+	RSA *pRsa  ;
+	const BIGNUM *p,*q,*dmp1,*dmq1,*iqmp,*n,*e,*d;
+	List *pList  ;
+	int nSize, nBits;
+	unsigned char* pBuf;
+	if ( RING_API_PARACOUNT != 1 ) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	pKey = (EVP_PKEY*) RING_API_GETCPOINTER(1,"OSSL_PKEY");
+	if ( pKey == NULL) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	/* check that this is indeed an RSA key */
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	if (EVP_PKEY_base_id(pKey) != EVP_PKEY_RSA) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	#else
+	if (EVP_PKEY_type(pKey->type) != EVP_PKEY_RSA) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	#endif
+	
+	pRsa = EVP_PKEY_get1_RSA(pKey);
+	
+	/* export all parameters */
+	#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	n = RSA_get0_n(pRsa);
+	e = RSA_get0_e(pRsa);
+	d = RSA_get0_d(pRsa);
+	p = RSA_get0_p(pRsa);
+	q = RSA_get0_q(pRsa);
+	dmp1 = RSA_get0_dmp1(pRsa);
+	dmq1 = RSA_get0_dmq1(pRsa);
+	iqmp = RSA_get0_iqmp(pRsa);
+	#else
+	n = pRsa->n;
+	e = pRsa->e;
+	d = pRsa->d;
+	p = pRsa->p;
+	q = pRsa->q;
+	dmp1 = pRsa->dmp1;
+	dmq1 = pRsa->dmq1;
+	iqmp = pRsa->iqmp;
+	#endif
+	
+	nBits = BN_num_bits(n);
+	
+	/* allocate a buffer that is enough to encode all components */
+	pBuf = (unsigned char*) RING_API_MALLOC(BN_num_bytes(n));
+	if (pBuf) {
+		pList = RING_API_NEWLIST;
+
+		ring_vm_openssl_add_bits_to_list(pPointer, nBits, pList);
+		ring_vm_openssl_add_keytype_to_list(pPointer, "RSA", pList);
+		ring_vm_openssl_add_bignum_to_list(pPointer, "n", n, pList, pBuf);
+		ring_vm_openssl_add_bignum_to_list(pPointer, "e", e, pList, pBuf);
+		ring_vm_openssl_add_bignum_to_list(pPointer, "d", d, pList, pBuf);
+		ring_vm_openssl_add_bignum_to_list(pPointer, "p", p, pList, pBuf);
+		ring_vm_openssl_add_bignum_to_list(pPointer, "q", q, pList, pBuf);
+		ring_vm_openssl_add_bignum_to_list(pPointer, "dmp1", dmp1, pList, pBuf);
+		ring_vm_openssl_add_bignum_to_list(pPointer, "dmq1", dmq1, pList, pBuf);
+		ring_vm_openssl_add_bignum_to_list(pPointer, "iqmp", iqmp, pList, pBuf);
+
+		RING_API_FREE(pBuf);
+		RING_API_RETLIST(pList);		
+	}
+	else {
+		RING_API_ERROR(RING_OOM);
+	}
+	
+	RSA_free(pRsa);
+}
+
+void ring_vm_openssl_rsa_export_pem ( void *pPointer )
+{
+	EVP_PKEY *pKey = NULL;
+	RSA *pRsa  ;
+	const BIGNUM *p,*q,*dmp1,*dmq1,*iqmp,*n,*e,*d;
+	BIO *bio;
+	int nSize,nStatus;
+	char* cStr;
+	if ( RING_API_PARACOUNT != 1 ) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	pKey = (EVP_PKEY*) RING_API_GETCPOINTER(1,"OSSL_PKEY");
+	if ( pKey == NULL) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	/* check that this is indeed an RSA key */
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	if (EVP_PKEY_base_id(pKey) != EVP_PKEY_RSA) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	#else
+	if (EVP_PKEY_type(pKey->type) != EVP_PKEY_RSA) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	#endif
+	
+	pRsa = EVP_PKEY_get1_RSA(pKey);
+	
+	/* export all parameters */
+	#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	n = RSA_get0_n(pRsa);
+	e = RSA_get0_e(pRsa);
+	d = RSA_get0_d(pRsa);
+	p = RSA_get0_p(pRsa);
+	q = RSA_get0_q(pRsa);
+	dmp1 = RSA_get0_dmp1(pRsa);
+	dmq1 = RSA_get0_dmq1(pRsa);
+	iqmp = RSA_get0_iqmp(pRsa);
+	#else
+	n = pRsa->n;
+	e = pRsa->e;
+	d = pRsa->d;
+	p = pRsa->p;
+	q = pRsa->q;
+	dmp1 = pRsa->dmp1;
+	dmq1 = pRsa->dmq1;
+	iqmp = pRsa->iqmp;
+	#endif
+	
+	/* n and e must not be NULL */
+	if (!n || !e) {
+		RSA_free(pRsa);
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+		return;
+	}
+	
+	bio = BIO_new(BIO_s_mem());
+	
+	if (d || (p && q && dmp1 && dmq1 && iqmp)) {
+		/* this is a private key */
+		nStatus = PEM_write_bio_PrivateKey(bio, pKey, NULL, NULL, 0, 0, NULL);
+	}
+	else {
+		/* this is a public key */
+		nStatus = PEM_write_bio_PUBKEY(bio, pKey);
+	}
+	
+	if (  nStatus > 0 ) {
+		nSize = (int) BIO_pending(bio);
+        /* Pre-allocated the return value on the stack */
+        RING_API_RETSTRINGSIZE(nSize);
+        cStr = ring_string_get(RING_API_GETSTRINGRAW);
+		BIO_read(bio, cStr, nSize);
+		BIO_free_all(bio);
+	}
+	else {
+		/* OpenSSL error */
+		RING_API_ERROR( ERR_reason_error_string(ERR_get_error()));
+	}
+	
+	RSA_free(pRsa);
+}
+
+void ring_vm_openssl_rsa_import_params ( void *pPointer )
+{
+	EVP_PKEY *pKey = NULL;
+	RSA *pRsa  ;
+	BIGNUM *p=NULL,*q=NULL,*dmp1=NULL,*dmq1=NULL,*iqmp=NULL,*n=NULL,*e=NULL,*d=NULL;
+	BIGNUM **targetComponent;
+	List *pList,*pSubList  ;
+	int x,nSize,nBits,nFailed,nBufSize;
+	char* cStrIndex;
+	unsigned char* pBuf;
+	if ( RING_API_PARACOUNT != 1 ) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	if ( ! RING_API_ISLIST(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	pList = RING_API_GETLIST(1);
+	nSize = ring_list_getsize(pList);
+	/* the minimal list is the one container the modulus and public exponent */
+	if ( nSize < 2) {
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+		return ;
+	}
+	
+	/* check that each element of the list is a list that has two string elements */
+	nFailed = 0;
+	for ( x = 1; x <= nSize ; x++ ) {
+		if ( !ring_list_islist(pList,x) ) {
+			nFailed = 1;
+			break ;
+		}
+		
+		pSubList = ring_list_getlist(pList,x);
+		if ( ring_list_getsize(pSubList) != 2 ) {
+			nFailed = 1;
+			break ;
+		}
+		if ( !ring_list_isstring(pSubList,1)) {
+			nFailed = 1;
+			break;
+		}
+		if ( !ring_list_isstring(pSubList,2)) {
+			continue;
+		}
+
+		cStrIndex = (char*) ring_list_getstring(pSubList,1);
+		pBuf = (unsigned char*) ring_list_getstring(pSubList,2);
+		nBufSize = (int) ring_list_getstringsize(pSubList,2);
+		
+		/* skip if the entry is empty */
+		if ( (*cStrIndex == 0) || (nBufSize == 0) ) {
+			continue;
+		}
+		
+		/* look for RSA components by name */
+		if ( strcmp(cStrIndex,"n") == 0) {
+			targetComponent = &n;
+		}
+		else if (strcmp(cStrIndex,"e") == 0) {
+			targetComponent = &e;
+		}
+		else if (strcmp(cStrIndex,"d") == 0) {
+			targetComponent = &d;
+		}
+		else if (strcmp(cStrIndex,"p") == 0) {
+			targetComponent = &p;
+		}
+		else if (strcmp(cStrIndex,"q") == 0) {
+			targetComponent = &q;
+		}
+		else if (strcmp(cStrIndex,"dmp1") == 0) {
+			targetComponent = &dmp1;
+		}
+		else if (strcmp(cStrIndex,"dmq1") == 0) {
+			targetComponent = &dmq1;
+		}
+		else if (strcmp(cStrIndex,"iqmp") == 0) {
+			targetComponent = &iqmp;
+		}
+		else {
+			targetComponent = NULL;
+		}
+		
+		if (targetComponent) {
+			/* if we have been already allocated, then return error since it means there is 
+			 * a duplicated entry in the list
+			 */
+			if ( *targetComponent )
+			{
+				nFailed = 1;
+				break;				
+			}
+
+			if ( !BN_hex2bn(targetComponent, (const char*) (pBuf)) ) {
+				nFailed = 1;
+				break;
+			}
+		}
+	}
+	
+	/* n and e must be set */
+	if ( (nFailed == 0) && (!n || !e) )
+	{
+		nFailed = 1;
+	}
+	
+	if ( nFailed == 0) {
+		/* create the key */
+		pRsa = RSA_new() ;
+		#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+		RSA_set0_key(pRsa,n,e,d);
+		RSA_set0_factors(pRsa,p,q);
+		RSA_set0_crt_params(pRsa,dmp1,dmq1,iqmp);
+		#else
+		pRsa->n = n;
+		pRsa->e = e;
+		pRsa->d = d;
+		pRsa->p = p;
+		pRsa->q = q;
+		pRsa->dmp1 = dmp1;
+		pRsa->dmq1 = dmq1;
+		pRsa->iqmp = iqmp;
+		#endif
+		/* memory management transfered to RSA object */
+		n = NULL;
+		e = NULL;
+		d = NULL;
+		p = NULL;
+		q = NULL;
+		dmp1 = NULL;
+		dmq1 = NULL;
+		iqmp = NULL;
+		
+		pKey = EVP_PKEY_new();
+		EVP_PKEY_assign_RSA(pKey, pRsa); /* pRsa is now owned by pKey */
+		/* success case: return the object */
+		RING_API_RETMANAGEDCPOINTER(pKey,"OSSL_PKEY",ring_vm_openssl_pkeyfree);
+	}
+	else
+	{
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+	}
+	
+	if (n) BN_free(n);
+	if (e) BN_free(e);
+	if (d) BN_free(d);
+	if (p) BN_free(p);
+	if (q) BN_free(q);
+	if (dmp1) BN_free(dmp1);
+	if (dmq1) BN_free(dmq1);
+	if (iqmp) BN_free(iqmp);
+}
+
+void ring_vm_openssl_rsa_import_pem ( void *pPointer )
+{
+	EVP_PKEY *pKey = NULL;
+	char* cStr;
+	int nSize,nStatus;
+	BIO *bio;
+	if ( RING_API_PARACOUNT != 1 ) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	if ( ! RING_API_ISSTRING(1) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	cStr = RING_API_GETSTRING(1);
+	nSize = RING_API_GETSTRINGSIZE(1);
+	if ( nSize < 2) {
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+		return ;
+	}
+	
+	bio = BIO_new(BIO_s_mem());
+	BIO_write(bio, cStr, nSize);
+	pKey = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
+	BIO_free_all(bio);
+	
+	if (!pKey) {
+		/* try public key import */
+		bio = BIO_new(BIO_s_mem());
+		BIO_write(bio, cStr, nSize);
+		pKey = PEM_read_bio_PUBKEY(bio, NULL, NULL, NULL);
+		BIO_free_all(bio);
+	}
+	
+	if (!pKey) {
+		/* invalid PEM */
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+		return ;
+	}
+	
+	/* check that this is indeed an RSA key */
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	if (EVP_PKEY_base_id(pKey) != EVP_PKEY_RSA) {
+		EVP_PKEY_free(pKey);
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+	}
+	#else
+	if (EVP_PKEY_type(pKey->type) != EVP_PKEY_RSA) {
+		EVP_PKEY_free(pKey);
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+	}
+	#endif
+	
+	/* success case: return the object */
+	RING_API_RETMANAGEDCPOINTER(pKey,"OSSL_PKEY",ring_vm_openssl_pkeyfree);
+}
+
+void ring_vm_openssl_rsa_encrypt_pkcs ( void *pPointer )
+{
+	EVP_PKEY *pKey = NULL;
+	RSA *pRsa = NULL  ;
+	int nSize, nModulusLen;
+	unsigned char *cInput, *cOutput;
+	if ( RING_API_PARACOUNT != 2  ) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) || ! RING_API_ISSTRING(2) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	pKey = (EVP_PKEY*) RING_API_GETCPOINTER(1,"OSSL_PKEY");
+	if ( pKey == NULL) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	/* check that this is indeed an RSA key */
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	if (EVP_PKEY_base_id(pKey) != EVP_PKEY_RSA) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	#else
+	if (EVP_PKEY_type(pKey->type) != EVP_PKEY_RSA) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	#endif
+	
+	cInput = (unsigned char*) RING_API_GETSTRING(2);
+	nSize = RING_API_GETSTRINGSIZE(2);
+
+	nModulusLen = EVP_PKEY_size(pKey);
+	
+	/* input size must be less than modulusLen - 11 */
+	if ( nSize > (nModulusLen - 11) ) {
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+		return ;
+	}
+	
+	cOutput = (unsigned char*) RING_API_MALLOC(nModulusLen);
+	if ( cOutput == NULL ) {
+		RING_API_ERROR(RING_OOM);
+		return;
+	}
+	
+	pRsa = EVP_PKEY_get1_RSA(pKey);
+	
+	if (RSA_public_encrypt(nSize, cInput,cOutput,pRsa,RSA_PKCS1_PADDING) != nModulusLen) {
+		/* OpenSSL error */
+		RING_API_ERROR( ERR_reason_error_string(ERR_get_error()));
+	}
+	else {
+		RING_API_RETSTRING2((const char*) cOutput,nModulusLen);
+	}
+	
+	
+	RING_API_FREE(cOutput);
+	RSA_free(pRsa);
+}
+
+void ring_vm_openssl_rsa_decrypt_pkcs ( void *pPointer )
+{
+	EVP_PKEY *pKey = NULL;
+	RSA *pRsa = NULL  ;
+	int nSize, nModulusLen, nOutput;
+	unsigned char *cInput, *cOutput;
+	if ( RING_API_PARACOUNT != 2  ) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) || ! RING_API_ISSTRING(2) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	pKey = (EVP_PKEY*) RING_API_GETCPOINTER(1,"OSSL_PKEY");
+	if ( pKey == NULL) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	/* check that this is indeed an RSA key */
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	if (EVP_PKEY_base_id(pKey) != EVP_PKEY_RSA) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	#else
+	if (EVP_PKEY_type(pKey->type) != EVP_PKEY_RSA) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	#endif
+	
+	cInput = (unsigned char*) RING_API_GETSTRING(2);
+	nSize = RING_API_GETSTRINGSIZE(2);
+
+	nModulusLen = EVP_PKEY_size(pKey);
+	
+	/* input size must be equal to modulusLen*/
+	if ( nSize != nModulusLen ) {
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+		return ;
+	}
+	
+	cOutput = (unsigned char*) RING_API_MALLOC(nModulusLen);
+	if ( cOutput == NULL ) {
+		RING_API_ERROR(RING_OOM);
+		return;
+	}
+	
+	pRsa = EVP_PKEY_get1_RSA(pKey);
+	
+	nOutput = RSA_private_decrypt(nSize, cInput,cOutput,pRsa,RSA_PKCS1_PADDING);
+	
+	if ( nOutput < 0 ) {
+		/* OpenSSL error */
+		RING_API_ERROR( ERR_reason_error_string(ERR_get_error()));
+	}
+	else {
+		RING_API_RETSTRING2((const char*) cOutput,nOutput);
+	}
+	
+	
+	RING_API_FREE(cOutput);
+	RSA_free(pRsa);
+}
+
+void ring_vm_openssl_rsa_encrypt_oaep ( void *pPointer )
+{
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	EVP_PKEY_CTX *ctx ;
+    size_t nOutput ;
+    int nStatus ;
+	#else
+	RSA *pRsa ;
+    int nOutput ;
+	#endif
+	EVP_PKEY *pKey ;
+	const EVP_MD *md ;
+	int nSize,nModulusLen,nMgfHashAlg;
+	unsigned char *cInput, *cOutput;
+	if ( RING_API_PARACOUNT != 2 && RING_API_PARACOUNT != 3 ) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) || ! RING_API_ISSTRING(2) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	if ( (RING_API_PARACOUNT == 3) && ! RING_API_ISNUMBER(3) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	pKey = (EVP_PKEY*) RING_API_GETCPOINTER(1,"OSSL_PKEY");
+	if ( pKey == NULL) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	/* check that this is indeed an RSA key */
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	if (EVP_PKEY_base_id(pKey) != EVP_PKEY_RSA) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	#else
+	if (EVP_PKEY_type(pKey->type) != EVP_PKEY_RSA) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	#endif
+	
+	if (RING_API_PARACOUNT == 3) {
+		nMgfHashAlg = (int) RING_API_GETNUMBER(3);
+	}
+	else {
+		/* use SHA1 by default */
+		nMgfHashAlg = OSSL_OAEP_SHA1;
+	}
+	
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	switch (nMgfHashAlg) {
+	case OSSL_OAEP_MD5: md = EVP_md5(); break;
+	case OSSL_OAEP_SHA1: md = EVP_sha1(); break;
+	case OSSL_OAEP_SHA256: md = EVP_sha256(); break;
+	case OSSL_OAEP_SHA384: md = EVP_sha384(); break;
+	case OSSL_OAEP_SHA512: md = EVP_sha512(); break;
+	default:
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+		return ;
+	}
+	#else
+	/* we support only SHA1 for old OpenSSL */
+	if (nMgfHashAlg != OSSL_OAEP_SHA1) {
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+		return ;
+	}
+	md = EVP_sha1();
+	#endif
+	
+	cInput = (unsigned char*) RING_API_GETSTRING(2);
+	nSize = RING_API_GETSTRINGSIZE(2);
+
+	nModulusLen = EVP_PKEY_size(pKey);
+	
+	/* input size for OAEP must be less than modulusLen - (2*hashSize) - 2 */
+	if ( nSize > (nModulusLen - (2 * EVP_MD_size(md)) - 2) ) {
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+		return ;
+	}
+	
+	cOutput = (unsigned char*) RING_API_MALLOC(nModulusLen);
+	if ( cOutput == NULL ) {
+		RING_API_ERROR(RING_OOM);
+		return;
+	}
+
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	nOutput = (size_t) nModulusLen;
+	ctx = EVP_PKEY_CTX_new(pKey,NULL);
+	if ( 	(EVP_PKEY_encrypt_init(ctx) > 0)
+		&&	(EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_OAEP_PADDING) > 0)
+		&&	(EVP_PKEY_CTX_set_rsa_oaep_md(ctx, md) > 0)
+		&&	(EVP_PKEY_CTX_set_rsa_mgf1_md(ctx, md) > 0)
+		) {
+		nStatus = EVP_PKEY_encrypt(ctx, cOutput, &nOutput, cInput, nSize);
+		if (  nStatus <= 0 ) {
+			/* error occured */
+			RING_API_ERROR( ERR_reason_error_string(ERR_get_error()));
+		}
+		else {
+			RING_API_RETSTRING2((const char*) cOutput,nModulusLen);
+		}
+	}
+	else {
+		RING_API_ERROR( ERR_reason_error_string(ERR_get_error()));
+	}
+	#else
+	pRsa = EVP_PKEY_get1_RSA(pKey);
+	nOutput = RSA_public_encrypt(nSize, cInput,cOutput,pRsa,RSA_PKCS1_OAEP_PADDING);
+	if ( nOutput == nModulusLen) {
+		RING_API_RETSTRING2((const char*) cOutput,nModulusLen);
+	}
+	else {
+		/* error occured */
+		RING_API_ERROR( ERR_reason_error_string(ERR_get_error()));
+	}
+	#endif
+
+
+	RING_API_FREE(cOutput);
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	EVP_PKEY_CTX_free(ctx);
+	#else
+	RSA_free(pRsa);
+	#endif
+}
+
+void ring_vm_openssl_rsa_decrypt_oaep ( void *pPointer )
+{
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	const EVP_MD *md;
+	EVP_PKEY_CTX *ctx;
+    size_t nOutput ;
+    int nStatus ;
+	#else
+	RSA *pRsa ;
+    int nOutput ;
+	#endif
+	EVP_PKEY *pKey;
+	int nSize,nModulusLen,nMgfHashAlg;
+	unsigned char *cInput, *cOutput;
+	if ( RING_API_PARACOUNT != 2 && RING_API_PARACOUNT != 3 ) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return ;
+	}
+	if ( ! RING_API_ISCPOINTER(1) || ! RING_API_ISSTRING(2) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	if ( (RING_API_PARACOUNT == 3) && ! RING_API_ISNUMBER(3) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	pKey = (EVP_PKEY*) RING_API_GETCPOINTER(1,"OSSL_PKEY");
+	if ( pKey == NULL) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	
+	/* check that this is indeed an RSA key */
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	if (EVP_PKEY_base_id(pKey) != EVP_PKEY_RSA) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	#else
+	if (EVP_PKEY_type(pKey->type) != EVP_PKEY_RSA) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	#endif
+	
+	if (RING_API_PARACOUNT == 3) {
+		nMgfHashAlg = (int) RING_API_GETNUMBER(3);
+	}
+	else {
+		/* use SHA1 by default */
+		nMgfHashAlg = OSSL_OAEP_SHA1;
+	}
+	
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	switch (nMgfHashAlg) {
+	case OSSL_OAEP_MD5: md = EVP_md5(); break;
+	case OSSL_OAEP_SHA1: md = EVP_sha1(); break;
+	case OSSL_OAEP_SHA256: md = EVP_sha256(); break;
+	case OSSL_OAEP_SHA384: md = EVP_sha384(); break;
+	case OSSL_OAEP_SHA512: md = EVP_sha512(); break;
+	default:
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+		return ;
+	}
+	#else
+	/* we support only SHA1 for old OpenSSL */
+	if (nMgfHashAlg != OSSL_OAEP_SHA1) {
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+		return ;
+	}
+	#endif
+	
+	cInput = (unsigned char*) RING_API_GETSTRING(2);
+	nSize = RING_API_GETSTRINGSIZE(2);
+
+	nModulusLen = EVP_PKEY_size(pKey);
+	
+	/* input size must be equal to modulusLen */
+	if ( nSize != nModulusLen ) {
+		RING_API_ERROR(RING_API_BADPARAVALUE);
+		return ;
+	}
+	
+	cOutput = (unsigned char*) RING_API_MALLOC(nModulusLen);
+	if ( cOutput == NULL ) {
+		RING_API_ERROR(RING_OOM);
+		return;
+	}
+
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	nOutput = (size_t) nModulusLen;
+	ctx = EVP_PKEY_CTX_new(pKey,NULL);
+	if ( 	(EVP_PKEY_decrypt_init(ctx) > 0)
+		&&	(EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_OAEP_PADDING) > 0)
+		&&	(EVP_PKEY_CTX_set_rsa_oaep_md(ctx, md) > 0)
+		&&	(EVP_PKEY_CTX_set_rsa_mgf1_md(ctx, md) > 0)
+		) {
+		if ( EVP_PKEY_decrypt(ctx, cOutput, &nOutput, cInput, (size_t) nSize) <= 0 ) {
+			/* error occured */
+			RING_API_ERROR( ERR_reason_error_string(ERR_get_error()));
+		}
+		else {
+			RING_API_RETSTRING2((const char*) cOutput,(int) nOutput);
+		}
+	}
+	else {
+		/* error occured */
+		RING_API_ERROR( ERR_reason_error_string(ERR_get_error()));
+	}
+	#else
+	pRsa = EVP_PKEY_get1_RSA(pKey);
+	nOutput = RSA_private_decrypt(nSize, cInput,cOutput,pRsa,RSA_PKCS1_OAEP_PADDING);
+	if ( nOutput < 0 ) {
+		/* unexpected error */
+		RING_API_ERROR( ERR_reason_error_string(ERR_get_error()));
+	}
+	else {
+		RING_API_RETSTRING2((const char*) cOutput,nOutput);
+	}
+	#endif
+
+	RING_API_FREE(cOutput);
+	#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+	EVP_PKEY_CTX_free(ctx);
+	#else
+	RSA_free(pRsa);
+	#endif
+}

--- a/extensions/ringopenssl/openssllib.ring
+++ b/extensions/ringopenssl/openssllib.ring
@@ -5,3 +5,9 @@ but ismacosx()
 else
 	LoadLib("libring_openssl.so")
 ok
+
+$OSSL_HASH_MD5    = 0
+$OSSL_HASH_SHA1   = 1
+$OSSL_HASH_SHA256 =	2
+$OSSL_HASH_SHA384 =	3
+$OSSL_HASH_SHA512 =	4

--- a/extensions/ringopenssl/ring_vmopenssl.h
+++ b/extensions/ringopenssl/ring_vmopenssl.h
@@ -57,9 +57,42 @@ void ring_vm_openssl_encrypt ( void *pPointer ) ;
 
 void ring_vm_openssl_decrypt ( void *pPointer ) ;
 
+void ring_vm_openssl_versiontext ( void *pPointer ) ;
+
+void ring_vm_openssl_version ( void *pPointer ) ;
+
 void ring_vm_openssl_randbytes ( void *pPointer ) ;
 
 void ring_vm_openssl_list_ciphers ( void *pPointer ) ;
+
+void ring_vm_openssl_rsa_new ( void *pPointer ) ;
+
+void ring_vm_openssl_rsa_generate ( void *pPointer ) ;
+
+void ring_vm_openssl_rsa_is_privatekey ( void *pPointer ) ;
+
+void ring_vm_openssl_rsa_export_params ( void *pPointer ) ;
+
+void ring_vm_openssl_rsa_import_params ( void *pPointer ) ;
+
+void ring_vm_openssl_rsa_export_pem ( void *pPointer ) ;
+
+void ring_vm_openssl_rsa_import_pem ( void *pPointer ) ;
+
+void ring_vm_openssl_rsa_encrypt_pkcs ( void *pPointer ) ;
+
+void ring_vm_openssl_rsa_decrypt_pkcs ( void *pPointer ) ;
+
+void ring_vm_openssl_rsa_encrypt_oaep ( void *pPointer ) ;
+
+void ring_vm_openssl_rsa_decrypt_oaep ( void *pPointer ) ;
 /* Constants */
 #define RING_VM_POINTER_OPENSSL "openssl"
+
+#define OSSL_OAEP_MD5		0
+#define OSSL_OAEP_SHA1		1
+#define OSSL_OAEP_SHA256	2
+#define OSSL_OAEP_SHA384	3
+#define OSSL_OAEP_SHA512	4
+
 #endif

--- a/extensions/ringopenssl/test_rsa.ring
+++ b/extensions/ringopenssl/test_rsa.ring
@@ -1,0 +1,157 @@
+Load "openssllib.ring"
+
+ver = openssl_version()
+OpenSSLVersionMajor = ver[1] 
+OpenSSLVersionMinor = ver[2] 
+OpenSSLVersionFix = ver[3] 
+See "Using " + openssl_versionText() + nl
+See "Numerical version = " + OpenSSLVersionMajor + "." + OpenSSLVersionMinor + "." + OpenSSLVersionFix + nl
+See nl
+
+for bitLength=1024 to 4096 step 1024
+	TestRsa(bitLength,65537) /* standard public exponent 0x010001 is the default*/
+	TestRsa(bitLength,3) /* a popular public exponent for faster encryption */
+next
+
+func TestRsa bitLength, pubExp
+	See "Testing " + bitLength + "-bits RSA with e=" + pubExp + nl
+	rsaKey = rsa_generate(bitLength, pubExp);
+	keyParams = rsa_export_params(rsaKey);
+
+	rsaKey2 = rsa_import_params(keyParams)
+	keyParams2 = rsa_export_params(rsaKey2);
+
+	publicParams = [:n = keyParams[:n], :e = keyParams[:e]]
+	rsaPubKey = rsa_import_params(publicParams)
+	publicParams = rsa_export_params(rsaPubKey)
+	rsaPubKey2 = rsa_import_params(publicParams)
+	publicParams2 = rsa_export_params(rsaPubKey)
+
+	if Compare(keyParams,keyParams2) See "  full param OK" + nl else See "  full param FAILED!" + nl ok
+	if Compare(publicParams,publicParams2) See "  public params OK" + nl else See "  public params FAILED!" + nl ok
+	
+	if keyParams[:bits] = bitLength See "  Bit length OK" + nl else See "  Bit length FAILED!!" + nl ok
+	
+	if rsa_is_privatekey(rsaKey) See "  Private key check OK" + nl else See "  Private Key check FAILED" + nl ok
+	if !rsa_is_privatekey(rsaPubKey) See "  Public key check OK" + nl else See "  Public Key check FAILED" + nl ok
+	
+	pemPrivate = rsa_export_pem(rsaKey)
+	pemPublic = rsa_export_pem(rsaPubKey)
+	
+	if (substr(pemPrivate,"-----BEGIN PRIVATE KEY-----") = 1) AND (Right(pemPrivate, 26) = ("-----END PRIVATE KEY-----" + nl))
+		See "  Private key PEM export OK" + nl
+	else
+		See "  Private key PEM export FAILED" + nl 
+	ok
+	
+	if (substr(pemPublic,"-----BEGIN PUBLIC KEY-----") = 1) AND (Right(pemPublic, 25) = ("-----END PUBLIC KEY-----" + nl))
+		See "  Public key PEM export OK" + nl
+	else
+		See "  Public key PEM export FAILED" + nl 
+	ok
+
+	data = randbytes(32)
+	ciphered = rsa_encrypt_pkcs(rsaPubKey, data)
+	data2 = rsa_decrypt_pkcs(rsaKey, ciphered)
+	
+	if data = data2 See "  test PKCS#1 encryption (32 bytes) OK" + nl else See "  test PKCS#1 encryption (32 bytes) failed!!" + nl ok
+
+	data = randbytes((bitLength + 7)/8 - 11)
+	ciphered = rsa_encrypt_pkcs(rsaPubKey, data)
+	data2 = rsa_decrypt_pkcs(rsaKey, ciphered)
+
+	if data = data2 See "  test PKCS#1 encryption (max size) OK" + nl else See "  test PKCS#1 encryption (max size) failed!!" + nl ok
+	
+	hashAlgorithms = [ $OSSL_HASH_MD5, $OSSL_HASH_SHA1, $OSSL_HASH_SHA256, $OSSL_HASH_SHA384, $OSSL_HASH_SHA512]
+	
+	for hashAlgo in hashAlgorithms
+			
+		maxInputLen = MaxOaepInputLength(bitLength,hashAlgo)
+		/* if using OpenSSL older than 1.0, skip hash algorithms other than SHA1 */
+		if (hashAlgo != $OSSL_HASH_SHA1) AND (OpenSSLVersionMajor < 1)
+			maxInputLen = 0
+		ok
+		
+		if maxInputLen = 0
+			See "  test OAEP-" + GetHashName(hashAlgo) + " encryption SKIPPED" + nl
+		else
+			try
+				data = randbytes(maxInputLen)
+				ciphered = rsa_encrypt_oaep(rsaPubKey, data, hashAlgo)
+				data2 = rsa_decrypt_oaep(rsaKey, ciphered, hashAlgo)
+				if data = data2 See "  test OAEP-" + GetHashName(hashAlgo) + " encryption (max size) OK" + nl else See "  test OAEP-" + GetHashName(hashAlgo) + " encryption (max size) failed!!" + nl ok
+				
+				/* test some input length*/
+				totalLoops = 0
+				successLoops = 0
+				for inputLen=1 to (maxInputLen-1) step 10
+					totalLoops++
+					data = randbytes(inputLen)
+					ciphered = rsa_encrypt_oaep(rsaPubKey, data, hashAlgo)
+					data2 = rsa_decrypt_oaep(rsaKey, ciphered, hashAlgo)
+					if data = data2 successLoops++ ok
+				next
+				
+				if successLoops = totalLoops See "  test OAEP-" + GetHashName(hashAlgo) + " encryption (various sizes) OK" + nl else See "  test OAEP-" + GetHashName(hashAlgo) + " encryption (various sizes) failed!!" + nl ok
+				
+			catch
+				See "  exception = " + cCatchError + nl
+			done
+		ok
+	next
+
+func MaxOaepInputLength RsaBitLength, hashAlgo
+	maxLen = ((RsaBitLength + 7)/8) - (2 * GetHashSize(hashAlgo)) - 2
+	if maxLen <= 0
+		return 0
+	else
+		return maxLen
+	ok
+	
+func GetHashName hashAlgo
+	switch hashAlgo
+	on $OSSL_HASH_MD5 	 return "MD5"
+	on $OSSL_HASH_SHA1 	 return "SHA1"
+	on $OSSL_HASH_SHA256 return "SHA256"
+	on $OSSL_HASH_SHA384 return "SHA384"
+	on $OSSL_HASH_SHA512 return "SHA512"
+	other return 0
+	off
+
+func GetHashSize hashAlgo
+	switch hashAlgo
+	on $OSSL_HASH_MD5 	 return 16
+	on $OSSL_HASH_SHA1 	 return 20
+	on $OSSL_HASH_SHA256 return 32
+	on $OSSL_HASH_SHA384 return 48
+	on $OSSL_HASH_SHA512 return 64
+	other return 0
+	off
+
+func PrintKeyElement(params, index, name)
+	See name + " = " + params[index] + nl
+	
+func Compare (list1,list2)
+	if islist(list1) and islist(list2)
+		if Len(list1) = Len(list2)
+			l = Len(list1)
+			for i=1 to l
+				if not Compare(list1[i],list2[i])
+					return false
+				ok
+			next
+			return true
+		else
+			return false
+		ok
+	elseif (isstring(list1) and isstring(list2)) or (isnumber(list1) and isnumber(list2))
+		if list1 = list2
+			return true
+		else
+			return false
+		ok
+	elseif isnull(list1) and isnull(list2)
+		return true
+	else
+		return false
+	ok


### PR DESCRIPTION
The script `test_rsa.ring` implements tests for all added functions and it can serve as a reference alongside the documentation.
Below is the list of added functions. The documentation (`secfunc.txt`) was updated with all details about these functions and examples of usage.
 - `rsa_generate`
 - `rsa_export_params`
 - `rsa_import_params`
 - `rsa_export_pem`
 - `rsa_import_pem`
 - `rsa_is_privatekey`
 - `rsa_encrypt_pkcs`
 - `rsa_decrypt_pkcs`
 - `rsa_encrypt_oaep`
 - `rsa_decrypt_oaep`
 - `openssl_versiontext`
 - `openssl_version`

One interesting point about `test_rsa.ring` is that I implemented a deep comparison function for lists (cf `Compare` in `test_rsa.ring`). It would have been helpful to have such function in the standard library.