### PR TITLE
Fix runtime check failure in Debug build caused by unintialized cStr2 variable

### DIFF
--- a/language/src/ring_vm.c
+++ b/language/src/ring_vm.c
@@ -1166,7 +1166,6 @@ RING_API void ring_vm_showerrormessage ( VM *pVM,const char *cStr )
             printf( "In %s() ",ring_list_getstring(pList,RING_FUNCCL_NAME) ) ;
         }
         lFunctionCall = 1 ;
-        cStr = cStr2 ;
     }
     if ( lFunctionCall ) {
         printf( "in file %s ",ring_list_getstring(pVM->pRingState->pRingFilesList,1) ) ;


### PR DESCRIPTION
This line is not needed at all since `cStr` is not meant to be changed (it is `const char*` parameter). removing this line fix the issue and doesn't change the behavior.