### PR TITLE
RingWinCReg: fix memory leaks

### DIFF
--- a/extensions/ringwincreg/creg_registry.cpp
+++ b/extensions/ringwincreg/creg_registry.cpp
@@ -798,7 +798,7 @@ LPTSTR CRegEntry::GetExpandSZ(bool Expandable) {
 		DWORD vSize = _MAX_REG_VALUE * 16; 
 		
 		_tcscpy(tmpStr, lpszStr);
-		
+		if (lpszStr) delete[] lpszStr;
 		lpszStr = new TCHAR[vSize];
 
 		ExpandEnvironmentStrings(tmpStr, lpszStr, vSize);
@@ -829,6 +829,7 @@ DWORD CRegEntry::SetExpandSZ(LPTSTR value) {
 
 	assert(svalue <= _MAX_REG_VALUE);
 
+	if (lpszStr) delete[] lpszStr;
 	lpszStr = new TCHAR[_MAX_REG_VALUE];
 	_tcscpy(lpszStr, value);
 
@@ -859,6 +860,7 @@ DWORD CRegEntry::SetExpandSZ(LPTSTR value) {
  */
 
 DWORD CRegEntry::SetQWORD(UINT64 value) {
+	if (lpszStr) delete[] lpszStr;
 	lpszStr = new TCHAR[21];		// limit of largest value of QWORD range (20) + NULL termination
 	DWORD lRes = 0;
 

--- a/extensions/ringwincreg/ring_wincreg.cpp
+++ b/extensions/ringwincreg/ring_wincreg.cpp
@@ -60,6 +60,13 @@ RING_LIBINIT
 	
 }
 
+static void ring_vm_creg_cregfree(void* pRingState, void* pPointer)
+{
+	CRegistry* pCR;
+	pCR = (CRegistry*)pPointer;
+	delete pCR;
+}
+
 // CRegistry cregopenkey ( RootHkey index /*like HKEY_CURRENT_USER*/ , string keyname , \optional int flags, \optional boolean access64tree )
 void ring_vm_creg_cregopenkey(void *pPointer){
 	CRegistry *pCR = new CRegistry;
@@ -129,7 +136,7 @@ void ring_vm_creg_cregopenkey(void *pPointer){
 	}
 	lResult = pCR->Open(RING_API_GETSTRING(2), hkey);
 	if ( lResult == ERROR_SUCCESS ) {
-		RING_API_RETCPOINTER(pCR, "CRegistry");
+		RING_API_RETMANAGEDCPOINTER(pCR, "CRegistry", ring_vm_creg_cregfree);
 		return;
 	} else {
 		TCHAR msgBuf[200];


### PR DESCRIPTION
The "CRegistry" pointer was never freed once created.
`lpszStr` member of `CRegEntry` was not freed first before being overwritten.