### PR TITLE
Fix stack overflow crash in parser on Windows when loading large RingQt files by setting stack reserved size to 8 MiB

### DIFF
--- a/language/src/buildvc.bat
+++ b/language/src/buildvc.bat
@@ -32,7 +32,7 @@ ring_ext.obj ring_dll_extension.obj ring_objfile.obj
 
 copy ..\..\lib\ring.dll ..\..\bin\
 
-cl %ringcflags% ring.c ..\..\lib\ring.lib -I"..\include" /link /SUBSYSTEM:CONSOLE,"%ringsubsystem%" /OUT:..\..\bin\ring.exe 
+cl %ringcflags% ring.c ..\..\lib\ring.lib -I"..\include" /link /SUBSYSTEM:CONSOLE,"%ringsubsystem%" /STACK:8388608 /OUT:..\..\bin\ring.exe 
 
 del *.obj
 

--- a/language/src/buildvc_debug.bat
+++ b/language/src/buildvc_debug.bat
@@ -32,7 +32,7 @@ ring_ext.obj ring_dll_extension.obj ring_objfile.obj
 
 copy ..\..\lib\ring.dll ..\..\bin\
 
-cl /DEBUG /Z7 %ringcflags% ring.c ..\..\lib\ring.lib -I"..\include" /link /SUBSYSTEM:CONSOLE,"%ringsubsystem%" /OUT:..\..\bin\ring.exe 
+cl /DEBUG /Z7 %ringcflags% ring.c ..\..\lib\ring.lib -I"..\include" /link /SUBSYSTEM:CONSOLE,"%ringsubsystem%" /STACK:8388608 /OUT:..\..\bin\ring.exe 
 
 del *.obj
 

--- a/language/src/buildvcstatic.bat
+++ b/language/src/buildvcstatic.bat
@@ -9,7 +9,7 @@ ring_stmt.c ring_expr.c ring_codegen.c ring_vm.c ring_vmexpr.c ring_vmvars.c ^
 ring_vmlists.c ring_vmfuncs.c ring_api.c ring_vmoop.c ring_vmcui.c ^
 ring_vmtrycatch.c ring_vmstrindex.c ring_vmjump.c ring_vmduprange.c ^
 ring_vmperformance.c ring_vmexit.c ring_vmstackvars.c ring_vmstate.c ring_generallib_extension.c ring_math_extension.c ring_file_extension.c ring_os_extension.c ring_list_extension.c ring_refmeta_extension.c ^
-ring_ext.c ring_dll_extension.c ring_objfile.c -I"..\include" /link /SUBSYSTEM:CONSOLE,"%ringsubsystem%" /OUT:..\..\bin\ring.exe 
+ring_ext.c ring_dll_extension.c ring_objfile.c -I"..\include" /link /SUBSYSTEM:CONSOLE,"%ringsubsystem%" /STACK:8388608 /OUT:..\..\bin\ring.exe 
 
 del *.obj
 

--- a/language/src/buildvcw.bat
+++ b/language/src/buildvcw.bat
@@ -22,7 +22,7 @@ ring_ext.obj ring_dll_extension.obj ring_objfile.obj
 
 copy ..\..\lib\ring.dll ..\..\bin\
 
-cl %ringcflags% ringw.c ..\..\lib\ring.lib -I"..\include"  advapi32.lib shell32.lib /link /SUBSYSTEM:WINDOWS,"%ringsubsystem%" /OUT:..\..\bin\ringw.exe
+cl %ringcflags% ringw.c ..\..\lib\ring.lib -I"..\include"  advapi32.lib shell32.lib /link /SUBSYSTEM:WINDOWS,"%ringsubsystem%" /STACK:8388608 /OUT:..\..\bin\ringw.exe
 
 del *.obj
 


### PR DESCRIPTION
Linux uses 8 MiB reserved stack size by default whereas Windows uses 1 MiB. Setting it explicitly to 8 MiB to match Linux and to fix the parser crash.