### PR TITLE
RingQt Windows: Fix conflict with existing Qt installations by forcing the use of Ring own distributed Qt

### DIFF
--- a/libraries/guilib/guilib.ring
+++ b/libraries/guilib/guilib.ring
@@ -8,6 +8,7 @@ C_USING_GUILIB = True
 
 # Load the DLL files 
 	if iswindows()
+		SysSet ("QT_QPA_PLATFORM_PLUGIN_PATH", exefolder())
 		LoadLib("ringqt.dll")
 	but ismacosx()
 		LoadLib("libringqt.dylib")

--- a/libraries/guilib/lightguilib.ring
+++ b/libraries/guilib/lightguilib.ring
@@ -8,6 +8,7 @@ C_USING_LIGHTGUILIB = True
 
 # Load the DLL files 
 	if iswindows()
+		SysSet ("QT_QPA_PLATFORM_PLUGIN_PATH", exefolder())
 		LoadLib("ringqt_light.dll")
 	but ismacosx()
 		LoadLib("libringqt_light.dylib")


### PR DESCRIPTION
Before loading `ringqt.dll` and `ringqt_light.dll`, we set the environment variable `QT_QPA_PLATFORM_PLUGIN_PATH` to the location of our executable file since this is where all our Qt dll are located.