### PR TITLE
Fixed Server Crash for POST Method Values

### DIFF
--- a/libraries/weblib/lib/functions.ring
+++ b/libraries/weblib/lib/functions.ring
@@ -27,7 +27,7 @@ Func LoadVars
 				cInput = input(sysget("CONTENT_LENGTH"))
 			else
 				cInput = ""
-			end
+			ok
 		ok
 		
 		aPageVars = decode(cInput)

--- a/libraries/weblib/lib/functions.ring
+++ b/libraries/weblib/lib/functions.ring
@@ -23,7 +23,11 @@ Func LoadVars
 	    	if sysget("REQUEST_METHOD") = "GET"
 			cInput = sysget("QUERY_STRING")
 		else
-			cInput = input(sysget("CONTENT_LENGTH"))
+			if sysget("CONTENT_LENGTH") > 0
+				cInput = input(sysget("CONTENT_LENGTH"))
+			else
+				cInput = ""
+			end
 		ok
 		
 		aPageVars = decode(cInput)


### PR DESCRIPTION
CONTENT-LENGTH returns 0 when there's no name attribute for input in form. That causes a crash.