### PR TITLE
fixed cursor position problem while using unicode

### DIFF
--- a/tools/ringnotepad/src/rnoteoutputwindow.ring
+++ b/tools/ringnotepad/src/rnoteoutputwindow.ring
@@ -43,6 +43,7 @@ class RNoteOutputWindow
 			cText = oProcessText.text() + nl
 		ok
 		oProcess.write(cText ,len(cText))
+		oProcessEditbox.movecursor(13,0)
 		oProcessEditbox.insertplaintext(cText)
 		oProcessText.setText("")
 


### PR DESCRIPTION
Hello Mahmoud,

Manoj Negi reported issue reproducible by

see "Enter your name حنين:  " give me
see nl
see "You are " + me

where unicode text is causing input to be inserted before the see text. I solved this by moving the cursor to end of the line.

P.S.

I used Arabic text from the Softanza lib, don't know the meaning.
