### PR TITLE
Fixed issue of real escape string

### DIFF
--- a/extensions/ringmysql/ring_vmmysql.c
+++ b/extensions/ringmysql/ring_vmmysql.c
@@ -308,8 +308,8 @@ void ring_vm_mysql_real_escape_string ( void *pPointer )
 		if ( con == NULL ) {
 			return ;
 		}
-		nSize = RING_API_GETSTRINGSIZE(2) ;
-		nSize2 = 2*nSize+1 ;
+		nSize = RING_API_GETSTRINGSIZE(2) -1 ;
+		nSize2 = 2*nSize ;
 		cStr = (char *) malloc(nSize2) ;
 		if ( cStr == NULL ) {
 			RING_API_ERROR(RING_OOM);


### PR DESCRIPTION
size + 1 was putting extra space in real space string output. Now it will have exact size as the provided string.
Ex. Output before 'Hello World ' 
     Output Now 'Hello World'