### PR TITLE
fixed self referencing

### DIFF
--- a/language/src/vmgc.c
+++ b/language/src/vmgc.c
@@ -283,6 +283,11 @@ RING_API List * ring_list_newref_gc ( void *pState, List *pVariableList, List *p
         pList->gc.pContainer = pVariableList ;
     }
     else {
+        /* If we don't have references here - it is a new reference! */
+        if ( ! ring_list_isref(pList) ) {
+            pList->gc.lNewRef = 1 ;
+            ring_list_updaterefcount_gc(pState,pList,RING_LISTREF_INC);
+        }
         pVariableList = (List *) pList->gc.pContainer ;
     }
     return pVariableList ;


### PR DESCRIPTION
Hello  Mahmoud,

I fixed case where self referencing is not increasing reference counter. Here is a test which fails

```Ring
tmp = new Temp { data="test2" }
cls2 = [ref(tmp)]
? refcount(tmp)
? "--------"
tmp=NULL
? refcount(cls2[1])
cls2[1] { tmp = ref(self) }
? tmp
? refcount(tmp)
? cls2[1]
? refcount(cls2[1])

class Temp
	data
```

BTW, all tests are passing now in Ring2B with temp memory deletion. It was easier than I thought because of lDontDelete.
What I miss now is information about collecting cycles code added last minute. I don't have this in Ring2B, but tests are passing. How come (assuming cycle and cycle2 are corresponding tests)?

Greetings,
Ilir
 