### PR TITLE
Expanding RingVM htable functionalities

### DIFF
--- a/extensions/ringsockets/ext/sockets.c
+++ b/extensions/ringsockets/ext/sockets.c
@@ -26,9 +26,9 @@ void ring_vm_socket_init(void *pPointer) {
 
 #ifdef _WIN32
     if (!g_bWinsockInitialized) {
-		RING_API_ERROR("WSAStartup Failed");
-		return;
-	}
+        RING_API_ERROR("WSAStartup Failed");
+        return;
+    }
 #endif
 
     if(RING_API_PARACOUNT < 2) {
@@ -58,7 +58,7 @@ void ring_vm_socket_init(void *pPointer) {
 
 
     sock->addr = NULL;
-	memset(&sock->hints, 0, sizeof(sock->hints));
+    memset(&sock->hints, 0, sizeof(sock->hints));
     sock->sockfd = INVALID_SOCKET;
     sock->hints.ai_family = (int) RING_API_GETNUMBER(1);
     sock->hints.ai_socktype = (int) RING_API_GETNUMBER(2);
@@ -70,7 +70,7 @@ void ring_vm_socket_init(void *pPointer) {
     
     if((sock->sockfd = socket(sock->hints.ai_family, sock->hints.ai_socktype, sock->hints.ai_protocol)) == INVALID_SOCKET) {
         RING_API_ERROR("Sock Init Failed");
-		RING_API_FREE(sock);
+        RING_API_FREE(sock);
         return;
     }
     
@@ -84,10 +84,10 @@ void ring_vm_socket_setsockopt(void *pPointer) {
     int level, optname, value;
 
 #ifdef _WIN32
-	if (!g_bWinsockInitialized) {
-		RING_API_ERROR("WSAStartup failed");
-		return;
-	}
+    if (!g_bWinsockInitialized) {
+        RING_API_ERROR("WSAStartup failed");
+        return;
+    }
 #endif
 
     if(RING_API_PARACOUNT != 4) 
@@ -121,10 +121,10 @@ void ring_vm_socket_getsockopt(void *pPointer) {
     int level, optname, valsize, buffer = 0;
 
 #ifdef _WIN32
-	if (!g_bWinsockInitialized) {
-		RING_API_ERROR("WSAStartup failed");
-		return;
-	}
+    if (!g_bWinsockInitialized) {
+        RING_API_ERROR("WSAStartup failed");
+        return;
+    }
 #endif
 
     if(RING_API_PARACOUNT != 3) 
@@ -254,7 +254,7 @@ void ring_vm_socket_accept(void *pPointer) {
 
     if((newsock->sockfd = accept(sock->sockfd, (struct sockaddr *) sock->addr, (socklen_t *)&nSize)) == SOCKET_ERROR) {
         RING_API_ERROR("Accept Failed");
-		RING_API_FREE(newsock);
+        RING_API_FREE(newsock);
         return;
     }
 
@@ -994,16 +994,16 @@ RING_API void ringlib_init(RingState *pRingState) {
     RING_API_REGISTER("socketscleanup",ring_vm_socket_cleanup);
 	
 #ifdef _WIN32
-	{
-		/* initialize Winsock */
-		WSADATA data;
-		if (WSAStartup(MAKEWORD(2, 2), &data) == 0) {
-			g_bWinsockInitialized = TRUE;
-		}
-		else {
-			g_bWinsockInitialized = FALSE;
-		}
-	}
+    {
+        /* initialize Winsock */
+        WSADATA data;
+        if (WSAStartup(MAKEWORD(2, 2), &data) == 0) {
+            g_bWinsockInitialized = TRUE;
+        }
+        else {
+            g_bWinsockInitialized = FALSE;
+        }
+    }
 #endif
 
 }

--- a/language/include/rhtable.h
+++ b/language/include/rhtable.h
@@ -1,5 +1,7 @@
 /* Copyright (c) 2013-2024 Mahmoud Fayed <msfclipper@yahoo.com> */
 
+// Updated & Enhanced by Abdallah Mohamed ( @0xNinjaCyclone )
+
 #ifndef ring_hashtable_h
 	#define ring_hashtable_h
 	/* Data */
@@ -8,6 +10,10 @@
 		union HashValue {
 			int nIndex  ;
 			void *pValue  ;
+			double dValue ;
+			char *cpStr ;
+			List *pList ;
+			void (*fpFunc)(void *) ;
 		} HashValue ;
 		struct HashItem *pNext  ;
 		char nItemType  ;
@@ -20,8 +26,13 @@
 	} HashTable ;
 	/* Constants */
 	#define RING_HASHITEMTYPE_NOTYPE 0
-	#define RING_HASHITEMTYPE_NUMBER 1
+	#define RING_HASHITEMTYPE_INTEGER 1
+	#define RING_HASHITEMTYPE_NUMBER RING_HASHITEMTYPE_INTEGER
 	#define RING_HASHITEMTYPE_POINTER 2
+	#define RING_HASHITEMTYPE_DOUBLE 3
+	#define RING_HASHITEMTYPE_STRING 4
+	#define RING_HASHITEMTYPE_LIST 5
+	#define RING_HASHITEMTYPE_FUNCTIONPOINTER 6
 	#define RING_HASHTABLE_LINKEDLISTS 2
 	#define RING_HASHTABLE_REBUILDSIZE 7
 	/* Functions */
@@ -36,17 +47,67 @@
 
 	void ring_hashtable_newpointer_gc ( void *pRingState,HashTable *pHashTable,const char *cKey,void *pPointer ) ;
 
+	int ring_hashtable_insertint_gc ( void *pRingState, HashTable *pHashTable, const char *cKey, int nNumber ) ;
+
+	int ring_hashtable_insertptr_gc ( void *pRingState, HashTable *pHashTable, const char *cKey,void *pPointer ) ;
+
+	int ring_hashtable_insertdbl_gc ( void *pRingState, HashTable *pHashTable, const char *cKey, double dNumber ) ;
+
+	int ring_hashtable_insertstr_gc ( void *pRingState, HashTable *pHashTable, const char *cKey, char *cpStr ) ;
+
+	int ring_hashtable_insertlst_gc ( void *pRingState, HashTable *pHashTable, const char *cKey, List *pList ) ;
+
+	int ring_hashtable_insertfnp_gc ( void *pRingState, HashTable *pHashTable, const char *cKey, void (*fpFunc)(void *) ) ;
+
+	int ring_hashtable_updateint ( HashTable *pHashTable, const char *cKey, int nNumber ) ;
+
+	int ring_hashtable_updateptr ( HashTable *pHashTable, const char *cKey, void *pPointer ) ;
+
+	int ring_hashtable_updatedbl ( HashTable *pHashTable, const char *cKey, double dNumber ) ;
+
+	int ring_hashtable_updatestr ( HashTable *pHashTable, const char *cKey, char *cpStr ) ;
+
+	int ring_hashtable_updatelst ( HashTable *pHashTable, const char *cKey, List *pList ) ;
+
+	int ring_hashtable_updatefnp ( HashTable *pHashTable, const char *cKey, void (*fpFunc)(void *) ) ;
+
 	HashItem * ring_hashtable_finditem ( HashTable *pHashTable,const char *cKey ) ;
 
 	int ring_hashtable_findnumber ( HashTable *pHashTable,const char *cKey ) ;
 
 	void * ring_hashtable_findpointer ( HashTable *pHashTable,const char *cKey ) ;
 
+	double ring_hashtable_finddouble ( HashTable *pHashTable,const char *cKey ) ;
+
+	char *ring_hashtable_findstring ( HashTable *pHashTable,const char *cKey ) ;
+
+	List *ring_hashtable_findlist ( HashTable *pHashTable,const char *cKey ) ;
+
+	void (*ring_hashtable_findfunctionpointer( HashTable *pHashTable,const char *cKey ))(void *) ;
+
 	void ring_hashtable_deleteitem_gc ( void *pRingState,HashTable *pHashTable,const char *cKey ) ;
+
+	int ring_hashtable_deleteitem2_gc ( void *pRingState, HashTable *pHashTable, const char *cKey ) ;
 
 	HashTable * ring_hashtable_delete_gc ( void *pRingState,HashTable *pHashTable ) ;
 
+	int ring_hashtable_first ( HashTable *pHashTable, unsigned int *unpPosition, char **cpKey, HashItem **pItem ) ;
+
+	int ring_hashtable_next ( HashTable *pHashTable, unsigned int *unpPosition, char **cpKey, HashItem **pItem ) ;
+
 	void ring_hashtable_print ( HashTable *pHashTable ) ;
+
+	void ring_hashtable_print2 ( HashTable *pHashTable ) ;
+
+	int ring_hashtable_haskey ( HashTable *pHashTable, const char *cpKey ) ;
+
+	int ring_hashtable_gettype ( HashTable *pHashTable, const char *cpKey ) ;
+
+	int ring_hashtable_compare ( HashTable *pHashTable, HashTable *pHashTable2 ) ;
+
+	List *ring_hashtable_getkeys_gc ( void *pRingState, HashTable *pHashTable ) ;
+
+	HashTable *ring_hashtable_clone_gc ( void *pRingState, HashTable *pHashTable ) ;
 
 	void ring_hashtable_rebuild_gc ( void *pRingState,HashTable *pHashTable ) ;
 	/* Functions without the State pointer */
@@ -57,6 +118,10 @@
 
 	void ring_hashtable_deleteitem ( HashTable *pHashTable,const char *cKey ) ;
 
+	void ring_hashtable_deleteitem ( HashTable *pHashTable, const char *cKey ) ;
+
+	int ring_hashtable_deleteitem2 ( HashTable *pHashTable, const char *cKey ) ;
+
 	HashTable * ring_hashtable_delete ( HashTable *pHashTable ) ;
 
 	void ring_hashtable_rebuild ( HashTable *pHashTable ) ;
@@ -64,4 +129,21 @@
 	void ring_hashtable_newnumber ( HashTable *pHashTable,const char *cKey,int nNumber ) ;
 
 	void ring_hashtable_newpointer ( HashTable *pHashTable,const char *cKey,void *pPointer ) ;
+
+	int ring_hashtable_insertint ( HashTable *pHashTable, const char *cKey, int nNumber ) ;
+
+	int ring_hashtable_insertptr ( HashTable *pHashTable, const char *cKey,void *pPointer ) ;
+
+	int ring_hashtable_insertdbl ( HashTable *pHashTable, const char *cKey, double dNumber ) ;
+
+	int ring_hashtable_insertstr ( HashTable *pHashTable, const char *cKey, char *cpStr ) ;
+
+	int ring_hashtable_insertlst ( HashTable *pHashTable, const char *cKey, List *pList ) ;
+
+	int ring_hashtable_insertfnp ( HashTable *pHashTable, const char *cKey, void (*fpFunc)(void *) ) ;
+
+	List *ring_hashtable_getkeys( HashTable *pHashTable ) ;
+
+	HashTable *ring_hashtable_clone ( HashTable *pHashTable ) ;
+
 #endif

--- a/language/src/rhtable.c
+++ b/language/src/rhtable.c
@@ -1,5 +1,7 @@
 /* Copyright (c) 2013-2024 Mahmoud Fayed <msfclipper@yahoo.com> */
 
+// Updated & Enhanced by Abdallah Mohamed ( @0xNinjaCyclone )
+
 #include "ring.h"
 
 HashTable * ring_hashtable_new_gc ( void *pRingState )
@@ -34,10 +36,22 @@ HashItem * ring_hashtable_newitem_gc ( void *pRingState,HashTable *pHashTable,co
 		pItem = pHashTable->pArray[nIndex] ;
 		/* Find Position of the HashItem */
 		while ( pItem->pNext != NULL ) {
+			/* To avoid duplicating an exist items */
+			if ( strcmp(cKey, pItem->cKey) == 0 ) {
+				return NULL;
+			}
 			pItem = pItem->pNext ;
+		}
+		/* Check the last item */
+		if ( strcmp(cKey, pItem->cKey) == 0 ) {
+			return NULL;
 		}
 		pItem->pNext = (HashItem *) ring_state_malloc(pRingState,sizeof(HashItem));
 		pItem = pItem->pNext ;
+	}
+	/* Check if the allocation gets failed */
+	if ( !pItem ) {
+		return NULL;
 	}
 	/* Store Copy from The Key */
 	pItem->cKey = ring_string_strdup(pRingState,cKey) ;
@@ -51,22 +65,192 @@ HashItem * ring_hashtable_newitem_gc ( void *pRingState,HashTable *pHashTable,co
 
 void ring_hashtable_newnumber_gc ( void *pRingState,HashTable *pHashTable,const char *cKey,int nNumber )
 {
-	HashItem *pItem  ;
-	pItem = ring_hashtable_newitem_gc(pRingState,pHashTable,cKey);
-	pItem->nItemType = RING_HASHITEMTYPE_NUMBER ;
-	pItem->HashValue.nIndex = nNumber ;
-	/* Check Rebuilding the HashTable */
-	ring_hashtable_rebuild_gc(pRingState,pHashTable);
+	ring_hashtable_insertint_gc( pRingState, pHashTable, cKey, nNumber );
 }
 
 void ring_hashtable_newpointer_gc ( void *pRingState,HashTable *pHashTable,const char *cKey,void *pPointer )
 {
+	ring_hashtable_insertptr_gc( pRingState, pHashTable, cKey, pPointer );
+}
+
+int ring_hashtable_insertint_gc ( void *pRingState, HashTable *pHashTable, const char *cKey, int nNumber )
+{
 	HashItem *pItem  ;
-	pItem = ring_hashtable_newitem_gc(pRingState,pHashTable,cKey);
-	pItem->nItemType = RING_HASHITEMTYPE_POINTER ;
-	pItem->HashValue.pValue = pPointer ;
-	/* Check Rebuilding the HashTable */
-	ring_hashtable_rebuild_gc(pRingState,pHashTable);
+	pItem = ring_hashtable_newitem_gc( pRingState, pHashTable, cKey );
+
+	if ( pItem ) {
+		pItem->nItemType = RING_HASHITEMTYPE_NUMBER ;
+		pItem->HashValue.nIndex = nNumber ;
+		/* Check Rebuilding the HashTable */
+		ring_hashtable_rebuild_gc( pRingState, pHashTable );
+		return 1;
+	}
+
+	return 0;
+}
+
+int ring_hashtable_insertptr_gc ( void *pRingState, HashTable *pHashTable, const char *cKey,void *pPointer )
+{
+	HashItem *pItem  ;
+	pItem = ring_hashtable_newitem_gc( pRingState, pHashTable, cKey );
+
+	if ( pItem ) {
+		pItem->nItemType = RING_HASHITEMTYPE_POINTER ;
+		pItem->HashValue.pValue = pPointer ;
+		/* Check Rebuilding the HashTable */
+		ring_hashtable_rebuild_gc( pRingState, pHashTable );
+		return 1;
+	}
+
+	return 0;
+}
+
+int ring_hashtable_insertdbl_gc ( void *pRingState, HashTable *pHashTable, const char *cKey, double dNumber )
+{
+	HashItem *pItem  ;
+	pItem = ring_hashtable_newitem_gc( pRingState, pHashTable, cKey );
+
+	if ( pItem ) {
+		pItem->nItemType = RING_HASHITEMTYPE_DOUBLE ;
+		pItem->HashValue.dValue = dNumber ;
+		/* Check Rebuilding the HashTable */
+		ring_hashtable_rebuild_gc( pRingState, pHashTable );
+		return 1;
+	}
+
+	return 0;
+}
+
+int ring_hashtable_insertstr_gc ( void *pRingState, HashTable *pHashTable, const char *cKey, char *cpStr ) 
+{
+	HashItem *pItem  ;
+	pItem = ring_hashtable_newitem_gc( pRingState, pHashTable, cKey );
+
+	if ( pItem ) {
+		pItem->nItemType = RING_HASHITEMTYPE_STRING ;
+		pItem->HashValue.cpStr = cpStr ;
+		/* Check Rebuilding the HashTable */
+		ring_hashtable_rebuild_gc( pRingState, pHashTable );
+		return 1;
+	}
+
+	return 0;
+}
+
+int ring_hashtable_insertlst_gc ( void *pRingState, HashTable *pHashTable, const char *cKey, List *pList ) 
+{
+	HashItem *pItem  ;
+	pItem = ring_hashtable_newitem_gc( pRingState, pHashTable, cKey );
+
+	if ( pItem ) {
+		pItem->nItemType = RING_HASHITEMTYPE_LIST ;
+		pItem->HashValue.pList = pList ;
+		/* Check Rebuilding the HashTable */
+		ring_hashtable_rebuild_gc( pRingState, pHashTable );
+		return 1;
+	}
+
+	return 0;
+}
+
+int ring_hashtable_insertfnp_gc ( void *pRingState, HashTable *pHashTable, const char *cKey, void (*fpFunc)(void *) )
+{
+	HashItem *pItem  ;
+	pItem = ring_hashtable_newitem_gc( pRingState, pHashTable, cKey );
+
+	if ( pItem ) {
+		pItem->nItemType = RING_HASHITEMTYPE_FUNCTIONPOINTER ;
+		pItem->HashValue.fpFunc = fpFunc ;
+		/* Check Rebuilding the HashTable */
+		ring_hashtable_rebuild_gc( pRingState, pHashTable );
+		return 1;
+	}
+
+	return 0;
+}
+
+int ring_hashtable_updateint ( HashTable *pHashTable, const char *cKey, int nNumber )
+{
+	HashItem *pItem;
+	pItem = ring_hashtable_finditem( pHashTable, cKey );
+
+	if ( pItem ) {
+		pItem->HashValue.nIndex = nNumber;
+		pItem->nItemType = RING_HASHITEMTYPE_INTEGER;
+		return 1;
+	}
+
+	return 0;
+}
+
+int ring_hashtable_updateptr ( HashTable *pHashTable, const char *cKey, void *pPointer )
+{
+	HashItem *pItem;
+	pItem = ring_hashtable_finditem( pHashTable, cKey );
+
+	if ( pItem ) {
+		pItem->HashValue.pValue = pPointer;
+		pItem->nItemType = RING_HASHITEMTYPE_POINTER;
+		return 1;
+	}
+
+	return 0;
+}
+
+int ring_hashtable_updatedbl ( HashTable *pHashTable, const char *cKey, double dNumber )
+{
+	HashItem *pItem;
+	pItem = ring_hashtable_finditem( pHashTable, cKey );
+
+	if ( pItem ) {
+		pItem->HashValue.dValue = dNumber;
+		pItem->nItemType = RING_HASHITEMTYPE_DOUBLE;
+		return 1;
+	}
+
+	return 0;
+}
+
+int ring_hashtable_updatestr ( HashTable *pHashTable, const char *cKey, char *cpStr )
+{
+	HashItem *pItem;
+	pItem = ring_hashtable_finditem( pHashTable, cKey );
+
+	if ( pItem ) {
+		pItem->HashValue.cpStr = cpStr;
+		pItem->nItemType = RING_HASHITEMTYPE_STRING;
+		return 1;
+	}
+
+	return 0;
+}
+
+int ring_hashtable_updatelst ( HashTable *pHashTable, const char *cKey, List *pList )
+{
+	HashItem *pItem;
+	pItem = ring_hashtable_finditem( pHashTable, cKey );
+
+	if ( pItem ) {
+		pItem->HashValue.pList = pList;
+		pItem->nItemType = RING_HASHITEMTYPE_LIST;
+		return 1;
+	}
+
+	return 0;
+}
+
+int ring_hashtable_updatefnp ( HashTable *pHashTable, const char *cKey, void (*fpFunc)(void *) )
+{
+	HashItem *pItem;
+	pItem = ring_hashtable_finditem( pHashTable, cKey );
+
+	if ( pItem ) {
+		pItem->HashValue.fpFunc = fpFunc;
+		pItem->nItemType = RING_HASHITEMTYPE_LIST;
+		return 1;
+	}
+
+	return 0;
 }
 
 HashItem * ring_hashtable_finditem ( HashTable *pHashTable,const char *cKey )
@@ -105,7 +289,52 @@ void * ring_hashtable_findpointer ( HashTable *pHashTable,const char *cKey )
 	return NULL ;
 }
 
+double ring_hashtable_finddouble ( HashTable *pHashTable,const char *cKey )
+{
+	HashItem *pItem  ;
+	pItem = ring_hashtable_finditem(pHashTable,cKey);
+	if ( pItem != NULL ) {
+		return pItem->HashValue.dValue ;
+	}
+	return 0 ;
+}
+
+char *ring_hashtable_findstring ( HashTable *pHashTable,const char *cKey )
+{
+	HashItem *pItem  ;
+	pItem = ring_hashtable_finditem(pHashTable,cKey);
+	if ( pItem != NULL ) {
+		return pItem->HashValue.cpStr ;
+	}
+	return NULL ;
+}
+
+List *ring_hashtable_findlist ( HashTable *pHashTable,const char *cKey )
+{
+	HashItem *pItem  ;
+	pItem = ring_hashtable_finditem(pHashTable,cKey);
+	if ( pItem != NULL ) {
+		return pItem->HashValue.pList ;
+	}
+	return NULL ;
+}
+
+void (*ring_hashtable_findfunctionpointer( HashTable *pHashTable,const char *cKey ))(void *) 
+{
+	HashItem *pItem  ;
+	pItem = ring_hashtable_finditem(pHashTable,cKey);
+	if ( pItem != NULL ) {
+		return pItem->HashValue.fpFunc ;
+	}
+	return NULL ;
+}
+
 void ring_hashtable_deleteitem_gc ( void *pRingState,HashTable *pHashTable,const char *cKey )
+{
+	ring_hashtable_deleteitem2_gc( pRingState, pHashTable, cKey );
+}
+
+int ring_hashtable_deleteitem2_gc ( void *pRingState, HashTable *pHashTable, const char *cKey ) 
 {
 	int nIndex  ;
 	HashItem *pItem, *pPrevItem  ;
@@ -123,11 +352,15 @@ void ring_hashtable_deleteitem_gc ( void *pRingState,HashTable *pHashTable,const
 			}
 			ring_state_free(pRingState,pItem->cKey);
 			ring_state_free(pRingState,pItem);
-			return ;
+			// Decrease the counter
+			pHashTable->nItems--;
+			return 1;
 		}
 		pPrevItem = pItem ;
 		pItem = pItem->pNext ;
 	}
+
+	return 0;
 }
 
 HashTable * ring_hashtable_delete_gc ( void *pRingState,HashTable *pHashTable )
@@ -177,6 +410,18 @@ void ring_hashtable_rebuild_gc ( void *pRingState,HashTable *pHashTable )
 			else if ( pItem->nItemType == RING_HASHITEMTYPE_POINTER ) {
 				ring_hashtable_newpointer(pHashTable,pItem->cKey,pItem->HashValue.pValue);
 			}
+			else if ( pItem->nItemType == RING_HASHITEMTYPE_DOUBLE ) {
+				ring_hashtable_insertdbl( pHashTable, pItem->cKey, pItem->HashValue.dValue );
+			}
+			else if ( pItem->nItemType == RING_HASHITEMTYPE_STRING ) {
+				ring_hashtable_insertstr( pHashTable, pItem->cKey, pItem->HashValue.cpStr );
+			}
+			else if ( pItem->nItemType == RING_HASHITEMTYPE_LIST ) {
+				ring_hashtable_insertlst( pHashTable, pItem->cKey, pItem->HashValue.pList );
+			}
+			else if ( pItem->nItemType == RING_HASHITEMTYPE_FUNCTIONPOINTER ) {
+				ring_hashtable_insertfnp( pHashTable, pItem->cKey, pItem->HashValue.fpFunc );
+			}
 			pItem2 = pItem->pNext ;
 			ring_state_free(pRingState,pItem->cKey);
 			ring_state_free(pRingState,pItem);
@@ -184,6 +429,53 @@ void ring_hashtable_rebuild_gc ( void *pRingState,HashTable *pHashTable )
 		}
 	}
 	ring_state_free(pRingState,pArray);
+}
+
+int ring_hashtable_first ( HashTable *pHashTable, unsigned int *unpPosition, char **cpKey, HashItem **pItem )
+{
+	// Set to the first chain 
+	( *unpPosition ) = 0;
+
+	( *pItem ) = pHashTable->pArray[ *unpPosition ];
+
+	if ( !(*pItem) ) {
+		do {
+			if ( ++(*unpPosition) == pHashTable->nLinkedLists )
+				return 0; // The table is empty
+
+			( *pItem ) = pHashTable->pArray[ *unpPosition ];
+		} while ( !(*pItem) );
+	}
+
+	if ( *pItem ) {	
+		if ( cpKey )
+			( *cpKey ) = ( *pItem )->cKey;
+			
+		return 1;
+	}
+
+	return 0;
+}
+
+// This function faciliate traversing the table ( BE CAREFUL WHEN USE IT )
+int ring_hashtable_next ( HashTable *pHashTable, unsigned int *unpPosition, char **cpKey, HashItem **pItem )
+{
+	if ( (*pItem)->pNext )
+		( *pItem ) = ( *pItem )->pNext;
+	
+	else {
+		do {
+			if ( ++(*unpPosition) == pHashTable->nLinkedLists )
+				return 0; // We have reached the end of the chain
+
+			( *pItem ) = pHashTable->pArray[ *unpPosition ];
+		} while ( !(*pItem) );
+	}
+
+	if ( cpKey )
+		( *cpKey ) = ( *pItem )->cKey;
+
+	return 1;
 }
 
 void ring_hashtable_print ( HashTable *pHashTable )
@@ -200,6 +492,278 @@ void ring_hashtable_print ( HashTable *pHashTable )
 	}
 }
 
+void ring_hashtable_print2 ( HashTable *pHashTable )
+{
+	int x  ;
+	HashItem *pItem  ;
+	char *cpKey ;
+
+	printf("{ ");
+
+	if ( ring_hashtable_first(pHashTable, &x, &cpKey, &pItem) )
+		do {
+			printf( "'%s': ", cpKey ) ;
+			if ( pItem->nItemType == RING_HASHITEMTYPE_DOUBLE )
+				printf( "%ld", (long) pItem->HashValue.dValue );
+			else if ( pItem->nItemType == RING_HASHITEMTYPE_STRING )
+				printf( "'%s'", (char *)pItem->HashValue.cpStr );
+			else if ( pItem->nItemType != RING_HASHITEMTYPE_NOTYPE )
+				printf( "%p", pItem->HashValue.pValue );
+			else 
+				printf( "NOTYPE" );
+			printf(", ");
+		} while ( ring_hashtable_next(pHashTable, &x, &cpKey, &pItem) );
+	
+	printf("}\n");
+}
+
+int ring_hashtable_haskey ( HashTable *pHashTable, const char *cpKey )
+{
+	HashItem *pItem;
+	int nIdx;
+
+	// Get the entry index by the hash
+	nIdx = ring_hashtable_hashkey( pHashTable, cpKey );
+
+	// Points to the first item
+	pItem = pHashTable->pArray[ nIdx ];
+
+	// Iterate over all items
+	while ( pItem )
+	{
+		if ( strcmp(cpKey, pItem->cKey) == 0 )
+			return 1; // We have found the key
+
+		// Jump on the next item
+		pItem = pItem->pNext;
+	}
+
+	// There is no item with this key in the table
+	return 0;
+}
+
+List *ring_hashtable_getkeys_gc ( void *pRingState, HashTable *pHashTable )
+{
+	HashItem **pItemsTable, *pItem;
+	List *pKeys;
+	int nEntries;
+
+	// Intialize the keys list
+	if ( !(pKeys = ring_list_new_gc( pRingState, 0 )) )
+		return NULL;
+
+	// Points to the first item ptr
+	pItemsTable = pHashTable->pArray;
+
+	// Number of entries within the table
+	nEntries = pHashTable->nLinkedLists;
+
+	// Iterate over the table
+	while ( nEntries-- )
+	{
+		// Get the front item
+		pItem = *pItemsTable++;
+
+		// Traverse all the items under current chain
+		while ( pItem )
+		{
+			// Insert the key
+			ring_list_addstring_gc( pRingState, pKeys, pItem->cKey );
+
+			// Jump to the next item
+			pItem = pItem->pNext;
+		}
+	}
+
+	return pKeys;
+}
+
+HashTable *ring_hashtable_clone_gc ( void *pRingState, HashTable *pHashTable )
+{
+	HashTable *pNewTable;
+	HashItem *pItem, *pItem2, *pPrev, **pArray, **pArray2;
+	unsigned int unTableEntries;
+
+	pNewTable = ring_state_malloc( pRingState, sizeof(HashTable) );
+	if ( !pNewTable ) {
+		goto FINISH; 
+	}
+
+	// Copy states
+	pNewTable->nItems = pHashTable->nItems;
+	pNewTable->nLinkedLists = pHashTable->nLinkedLists;
+	pNewTable->nRebuildSize = pHashTable->nRebuildSize;
+
+	// Allocate new table
+	pNewTable->pArray = ring_state_calloc( pRingState, pNewTable->nLinkedLists, sizeof(HashItem *) );
+
+	// Failed to allocate a table?
+	if ( !pNewTable->pArray ) {
+		// Gets rid of the allocated table memory
+		ring_state_free( pRingState, pNewTable );
+		pNewTable = NULL;
+		goto FINISH; // Get the hell out of here
+	}
+
+	// Points to the front's ptr of the first chain
+	pArray = pHashTable->pArray;
+	pArray2 = pNewTable->pArray;
+
+	// Number of chains
+	unTableEntries = pHashTable->nLinkedLists;
+
+	// Copy all items one by one
+	while ( unTableEntries-- )
+	{
+		// Get the front of current chain
+		pItem = *pArray++;
+		pPrev = NULL;
+
+		while ( pItem )
+		{
+			pItem2 = ring_state_malloc( pRingState, sizeof(HashItem) );
+			
+			if ( !pItem2 ) {
+				// f*cking OOM case.
+				// We have to gets rid of the new table and return NULL to the caller
+				pArray = pNewTable->pArray;
+
+				// Number of processed chains within the new table
+				unTableEntries = pNewTable->nLinkedLists - unTableEntries;
+
+				// Iterate over all active chains
+				while ( unTableEntries-- )
+				{
+					// Get the front 
+					pItem = *pArray++;
+
+					// Traverse current chain and free all items
+					while ( pItem )
+					{
+						pItem2 = pItem->pNext;
+						ring_state_free( pRingState, pItem->cKey );
+						ring_state_free( pRingState, pItem );
+						pItem = pItem2;
+					}
+				}
+
+				ring_state_free( pRingState, pNewTable->pArray );
+				ring_state_free( pRingState, pNewTable );
+				pNewTable = NULL;
+				goto FINISH; // Get the hell out of here
+			}
+
+			// Copy the original Item
+			( *pItem2 ) = ( *pItem );
+
+			// Duplicate the key
+			pItem2->cKey = ring_string_strdup( pRingState, pItem->cKey );
+
+			// The next points to nothing
+			pItem2->pNext = NULL;
+
+			if ( pPrev ) {
+				pPrev->pNext = pItem2;
+				pPrev = pPrev->pNext;
+			}
+
+			else {
+				( *pArray2 ) = pItem2;
+				pPrev = *pArray2;
+			}
+
+			pItem = pItem->pNext;
+		}
+
+		pArray2++;
+	}
+
+FINISH:
+	return pNewTable;
+}
+
+int ring_hashtable_gettype ( HashTable *pHashTable, const char *cpKey )
+{
+	HashItem *pItem;
+	pItem = ring_hashtable_finditem( pHashTable, cpKey );
+
+	if ( pItem ) {
+		return pItem->nItemType;
+	}
+
+	return RING_HASHITEMTYPE_NOTYPE;
+}
+
+int ring_hashtable_compare ( HashTable *pHashTable, HashTable *pHashTable2 ) 
+{
+	HashItem *pItem, *pItem2, **pArray;
+	unsigned int unEntries;
+
+	if (!(
+		pHashTable->nLinkedLists == pHashTable2->nLinkedLists &&
+		pHashTable->nRebuildSize == pHashTable2->nRebuildSize &&
+		pHashTable->nItems == pHashTable2->nItems
+	)) {
+		return 0;
+	}
+
+	pArray = pHashTable->pArray;
+	unEntries = pHashTable->nLinkedLists;
+
+	while ( unEntries-- ) 
+	{
+		pItem = *pArray++;
+
+		while ( pItem )
+		{
+			// Search for the item
+			pItem2 = ring_hashtable_finditem( pHashTable2, pItem->cKey );
+
+			if ( !pItem2 )
+				return 0; // Current item's key doesn't exist
+
+			if ( pItem->nItemType != pItem2->nItemType )
+				return 0;
+
+			if ( pItem->nItemType == RING_HASHITEMTYPE_NUMBER ) {
+				if ( pItem->HashValue.nIndex != pItem2->HashValue.nIndex )
+					return 0;
+			}
+
+			else if ( pItem->nItemType == RING_HASHITEMTYPE_POINTER ) {
+				if ( pItem->HashValue.pValue != pItem2->HashValue.pValue )
+					return 0;
+			}
+
+			else if ( pItem->nItemType == RING_HASHITEMTYPE_DOUBLE ) {
+				if ( pItem->HashValue.dValue != pItem2->HashValue.dValue )
+					return 0;
+			}
+
+			else if ( pItem->nItemType == RING_HASHITEMTYPE_STRING ) {
+				if ( strcmp(pItem->HashValue.cpStr, pItem2->HashValue.cpStr) != 0 )
+					return 0;
+			}
+
+			else if ( pItem->nItemType == RING_HASHITEMTYPE_LIST ) {
+				// We check if both items have the same object
+				if ( pItem->HashValue.pList != pItem2->HashValue.pList )
+					return 0;
+			}
+
+			else if ( pItem->nItemType == RING_HASHITEMTYPE_FUNCTIONPOINTER ) {
+				if ( pItem->HashValue.fpFunc != pItem2->HashValue.fpFunc )
+					return 0;
+			}
+
+			pItem = pItem->pNext;
+		}
+
+	}
+
+	return 1;
+}
+
 HashTable * ring_hashtable_new ( void )
 {
 	return ring_hashtable_new_gc(NULL) ;
@@ -213,6 +777,11 @@ HashItem * ring_hashtable_newitem ( HashTable *pHashTable,const char *cKey )
 void ring_hashtable_deleteitem ( HashTable *pHashTable,const char *cKey )
 {
 	ring_hashtable_deleteitem_gc(NULL,pHashTable,cKey);
+}
+
+int ring_hashtable_deleteitem2 ( HashTable *pHashTable, const char *cKey )
+{
+	return ring_hashtable_deleteitem2_gc( NULL, pHashTable, cKey );
 }
 
 HashTable * ring_hashtable_delete ( HashTable *pHashTable )
@@ -233,4 +802,44 @@ void ring_hashtable_newnumber ( HashTable *pHashTable,const char *cKey,int nNumb
 void ring_hashtable_newpointer ( HashTable *pHashTable,const char *cKey,void *pPointer )
 {
 	ring_hashtable_newpointer_gc(NULL,pHashTable,cKey,pPointer);
+}
+
+int ring_hashtable_insertint ( HashTable *pHashTable, const char *cKey, int nNumber ) 
+{
+	return ring_hashtable_insertint_gc( NULL, pHashTable, cKey, nNumber );
+}
+
+int ring_hashtable_insertptr ( HashTable *pHashTable, const char *cKey,void *pPointer )
+{
+	return ring_hashtable_insertptr_gc( NULL, pHashTable, cKey, pPointer );
+}
+
+int ring_hashtable_insertdbl ( HashTable *pHashTable, const char *cKey, double dNumber )
+{
+	return ring_hashtable_insertdbl_gc( NULL, pHashTable, cKey, dNumber );
+}
+
+int ring_hashtable_insertstr ( HashTable *pHashTable, const char *cKey, char *cpStr )
+{
+	return ring_hashtable_insertstr_gc( NULL, pHashTable, cKey, cpStr );
+}
+
+int ring_hashtable_insertlst ( HashTable *pHashTable, const char *cKey, List *pList )
+{
+	return ring_hashtable_insertlst_gc( NULL, pHashTable, cKey, pList );
+}
+
+int ring_hashtable_insertfnp ( HashTable *pHashTable, const char *cKey, void (*fpFunc)(void *) )
+{
+	return ring_hashtable_insertfnp_gc( NULL, pHashTable, cKey, fpFunc );
+}
+
+List *ring_hashtable_getkeys( HashTable *pHashTable )
+{
+	return ring_hashtable_getkeys_gc( NULL, pHashTable );
+}
+
+HashTable *ring_hashtable_clone ( HashTable *pHashTable )
+{
+	return ring_hashtable_clone_gc( NULL, pHashTable );
 }


### PR DESCRIPTION
Hello Ring Team

After [this conversation](https://groups.google.com/g/ring-lang/c/AT7M_uh5JwI) with **Ilir Liburn**‏ while facing a problem in returning a hashtable via Ring C API.
I decided to expose the hash table functionalities to the ringworld to facilitate extension developers' work.
So I expanded its functionalities in order to expose them.
My update includes :-
- Expanding the item's data types 
- Adding insert/update/delete/clone/compare/find functions
- Adding functions facilitates traversing the table
- Adding functions exposes some information about the table like `haskey?` and `getkeys`
- Fix issues like the counter not decrementing when an item is deleted and the insert function not checking whether the new key already exists inside the table resulting in table pollution

My updates don't break any old functions. 
I have tested it well on a Linux machine and it works as expected.
I am currently working on the extension, and I already finished it but I wanted to send PRs separately to avoid confusing the reviewers.

Best regards,
**Abdallah Mohamed**.