### PR TITLE
Fix libzip compilation error using gcc 14

### DIFF
--- a/extensions/ringzip/libzip.cf
+++ b/extensions/ringzip/libzip.cf
@@ -21,7 +21,7 @@ struct buffer_t {
     size_t size;
 };
 
-static size_t on_extract(void *arg, unsigned long long offset, const void *data,size_t size) {
+static size_t on_extract(void *arg, uint64_t offset, const void *data,size_t size) {
     struct buffer_t *buf = (struct buffer_t *) arg;
     buf->data = realloc(buf->data, buf->size + size + 1);
     assert(NULL != buf->data);


### PR DESCRIPTION
Fix libzip compilation error using gcc 14

```c
./buildgcc.sh
In file included from zip.c:39,
                 from ring_libzip.c:14:
miniz.h:4988:9: note: '#pragma message: Using fopen, ftello, fseeko, stat() etc. path for file I/O - this path may not support large files.'
 4988 | #pragma message(                                                               \
      |         ^~~~~~~
ring_libzip.c: In function 'ring_zip_extract_file':
ring_libzip.c:298:40: error: passing argument 2 of 'zip_entry_extract' from incompatible pointer type [-Wincompatible-pointer-types]
  298 |                 zip_entry_extract(zip, on_extract, &buf);
      |                                        ^~~~~~~~~~
      |                                        |
      |                                        size_t (*)(void *, long long unsigned int,  const void *, size_t) {aka long unsigned int (*)(void *, long long unsigned int,  const void *, long unsigned int)}
zip.c:1526:32: note: expected 'size_t (*)(void *, uint64_t,  const void *, size_t)' {aka 'long unsigned int (*)(void *, long unsigned int,  const void *, long unsigned int)'} but argument is of type 'size_t (*)(void *, long long unsigned int,  const void *, size_t)' {aka 'long unsigned int (*)(void *, long long unsigned int,  const void *, long unsigned int)'}
 1526 |                       size_t (*on_extract)(void *arg, uint64_t offset,
      |                       ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1527 |                                            const void *buf, size_t bufsize),
      |                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
