### PR TITLE
Fix failure of SystemCmd function if current directory is not writable

### DIFF
--- a/libraries/stdlib/stdlibcore.ring
+++ b/libraries/stdlib/stdlibcore.ring
@@ -848,10 +848,12 @@ Func chomp(cStr)
 */
 
 func SystemCmd(cmd)
-	System(cmd + "> cmd.txt")
-	cStr = read("cmd.txt")
+	# generate writable temporary file path to use for command output
+	cTmpFilePath = tempname()
+	System(cmd + "> " + cTmpFilePath)
+	cStr = read(cTmpFilePath)
 	# delete result file after get value
-	OSDeleteFile("cmd.txt")
+	OSDeleteFile(cTmpFilePath)
 	if right(cStr,1) = nl
 		cStr = left(cStr,len(cStr)-1)
 	ok


### PR DESCRIPTION
`SystemCmd` implementation redirected command output to cmd.txt file in current directory which caused an error if the current directory is not writable by the current process.
Now we use the `tempname()` function to create a dedicated random temporary file for capturing command output which is guaranteed to be always writable.

An example of failing program when current directory is not writable:
``` ring
load "stdlibcore.ring"

cStr = SystemCmd("ver") # call raise error here if current directory is not writable
cStr = trimNewlines(cStr)

print("Windows version = " + cStr + nl)

# Remove leading and trailing newlines/carriage from string
func trimNewlines(str)
    if len(str) = 0 return str ok

    leadingCount = 0
    trailingCount = 0
    strLen = len(str)

    # Count leading newlines and carriage returns
    while leadingCount < strLen and (str[leadingCount + 1] = nl or str[leadingCount + 1] = cr)
        leadingCount++
    end

    # If the entire string is newlines/carriage returns, return an empty string
    if leadingCount = strLen return "" ok

    # Count trailing newlines and carriage returns
    while trailingCount < strLen - leadingCount and (str[strLen - trailingCount] = nl or str[strLen - trailingCount] = cr)
        trailingCount++
    end

    # Remove leading and trailing newlines/carriage returns in one step
    return substr(str, leadingCount + 1, strLen - leadingCount - trailingCount)
end
```

