### PR TITLE
Update `buildgccstatic.sh` - Make the Ring executable fully static

### DIFF
--- a/language/build/buildgccstatic.sh
+++ b/language/build/buildgccstatic.sh
@@ -1,7 +1,7 @@
 cd ../src
 
 clear
-gcc -O2 ring.c general.c state.c ext.c hashlib.c rhtable.c vmgc.c os_e.c rstring.c rlist.c ritem.c ritems.c scanner.c parser.c stmt.c expr.c codegen.c vm.c vmerror.c vmeval.c vmthread.c vmexpr.c vmvars.c vmlists.c vmfuncs.c ringapi.c vmoop.c  vmtry.c vmstr.c vmjump.c vmrange.c list_e.c meta_e.c vminfo_e.c vmperf.c vmexit.c vmstack.c vmstate.c genlib_e.c math_e.c file_e.c dll_e.c objfile.c -I $PWD/../include -o $PWD/../../bin/ring -lm -ldl
+gcc -O2 -static -s ring.c general.c state.c ext.c hashlib.c rhtable.c vmgc.c os_e.c rstring.c rlist.c ritem.c ritems.c scanner.c parser.c stmt.c expr.c codegen.c vm.c vmerror.c vmeval.c vmthread.c vmexpr.c vmvars.c vmlists.c vmfuncs.c ringapi.c vmoop.c  vmtry.c vmstr.c vmjump.c vmrange.c list_e.c meta_e.c vminfo_e.c vmperf.c vmexit.c vmstack.c vmstate.c genlib_e.c math_e.c file_e.c dll_e.c objfile.c -I $PWD/../include -o $PWD/../../bin/ring -lm -ldl
 
 cd ../../bin
 sudo ./install.sh


### PR DESCRIPTION
This update resolves issues where the `ring` executable fails to run due to missing `glibc` versions on older systems (specifically when running the executable compiled with a newer glibc version).

```c
./ring: /lib/aarch64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by ./ring)
./ring: /lib/aarch64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by ./ring)
./ring: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by ./ring)
./ring: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./ring)
```
This may also apply to the ring2exe `-static` argument on Linux too (If the ring script doesn't require any extensions, of course).