### PR TITLE
Fix fastpro build scripts

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -645,6 +645,8 @@ sudo cp extensions/ringtilengine/linux_tilengine/lib/*.so /usr/lib
 sudo cp extensions/ringtilengine/linux_tilengine/lib/*.so /usr/lib64
 fi
 
+# Make the RingPDFGen library ready for use directly
+
 if [ -f lib/libring_pdfgen.dylib ];
 then
 ln -sf "`pwd`/lib/libring_pdfgen.dylib" /usr/local/lib

--- a/extensions/ringfastpro/buildclang.sh
+++ b/extensions/ringfastpro/buildclang.sh
@@ -1,6 +1,2 @@
 clang -c -fpic -O2 fastpro.c -I $PWD/../../language/include
-clang -dynamiclib -o libring_fastpro.dylib fastpro.o  -L $PWD/../../lib  -lring
-cp libring_fastpro.dylib /usr/local/lib
- 
-
-
+clang -dynamiclib -o $PWD/../../lib/libring_fastpro.dylib fastpro.o  -L $PWD/../../lib  -lring 

--- a/extensions/ringfastpro/buildgcc.sh
+++ b/extensions/ringfastpro/buildgcc.sh
@@ -1,8 +1,3 @@
 gcc -c -fpic -O2 fastpro.c -I $PWD/../../language/include 
-gcc -shared -o libring_fastpro.so fastpro.o -L $PWD/../../lib -lring
-sudo cp libring_fastpro.so /usr/lib
-sudo cp libring_fastpro.so /usr/lib64
-
- 
-
+gcc -shared -o $PWD/../../lib/libring_fastpro.so fastpro.o -L $PWD/../../lib -lring
 


### PR DESCRIPTION
The `buildgcc.sh` and `buildclang.sh` scripts in RingFastPro do not output the library to the lib directory.