### PR TITLE
Add FreeBSD support for executable path retrieval

### DIFF
--- a/language/include/ring.h
+++ b/language/include/ring.h
@@ -32,6 +32,9 @@
 	#ifdef __ANDROID__
 		#define RING_SIMPLEHASHFUNC 1
 	#endif
+	#ifdef __FreeBSD__
+		#include <sys/sysctl.h>
+	#endif
 	#ifdef _WIN32
 		#include <io.h>
 		#include <fcntl.h>

--- a/language/src/general.c
+++ b/language/src/general.c
@@ -41,6 +41,14 @@ int ring_general_exefilename ( char *cDirPath )
 			strncpy(cDirPath,cCorrectPath,nSize) ;
 			free(cCorrectPath) ;
 		}
+	#elif __FreeBSD__
+		/* FreeBSD */
+		int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+		size_t cb = nSize;
+		memset(cDirPath, RING_ZERO, nSize);
+		if (sysctl(mib, 4, cDirPath, &cb, NULL, 0) != 0) {
+			return 0;
+		}
 	#elif __linux__
 		/* readlink() doesn't null terminate */
 		memset(cDirPath,RING_ZERO,nSize);


### PR DESCRIPTION
This commit fixes path issues like:

```sh
Error (E9) : Can't open file stdlibcore.ring

test.ring Line (8) Error (C27) : Syntax Error!
```
encountered on FreeBSD because the `exefolder()` function returned an empty string.

Tested on: FreeBSD 15.0-CURRENT
