### PR TITLE
Fix LibUV compilation on Linux with GCC 14/Clang 19+

### DIFF
--- a/extensions/ringlibuv/libuv.cf
+++ b/extensions/ringlibuv/libuv.cf
@@ -28,9 +28,9 @@ void *uv_new_mutex(void);
 RING_API void ringlib_init(RingState *pRingState)
 {
 	pVMLibUV = pRingState->pVM;
-	ring_vm_mutexfunctions(pVMLibUV,uv_new_mutex,
-                uv_mutex_lock,uv_mutex_unlock,uv_mutex_destroy);
-   	ring_libuv_start(pRingState) ;
+	ring_vm_mutexfunctions(pVMLibUV, uv_new_mutex,
+						   (void (*)(void *))uv_mutex_lock, (void (*)(void *))uv_mutex_unlock, (void (*)(void *))uv_mutex_destroy);
+	ring_libuv_start(pRingState);
 }
 
 

--- a/extensions/ringlibuv/ring_libuv.c
+++ b/extensions/ringlibuv/ring_libuv.c
@@ -20,9 +20,9 @@ void *uv_new_mutex(void);
 RING_API void ringlib_init(RingState *pRingState)
 {
 	pVMLibUV = pRingState->pVM;
-	ring_vm_mutexfunctions(pVMLibUV,uv_new_mutex,
-uv_mutex_lock,uv_mutex_unlock,uv_mutex_destroy);
-	ring_libuv_start(pRingState) ;
+	ring_vm_mutexfunctions(pVMLibUV, uv_new_mutex,
+						   (void (*)(void *))uv_mutex_lock, (void (*)(void *))uv_mutex_unlock, (void (*)(void *))uv_mutex_destroy);
+	ring_libuv_start(pRingState);
 }
 
 


### PR DESCRIPTION
* Add explicit casts to `uv_mutex_lock`, `uv_mutex_unlock`, and `uv_mutex_destroy` when passing them to ring_vm_mutexfunctions.
This resolves incompatible function pointer type errors caused by stricter type checking in newer compilers.

* Updated `ring_libuv.c` by regenerating it.

While testing LibUV on Linux, the first example (`ex1.ring`) works; however, the remaining examples do not function as they do on Windows. They are hanging, seemingly in an infinite loop.