### PR TITLE
Refactor: Optimize ring_state_realloc with RING_MEMCPY

### DIFF
--- a/language/src/vmgc.c
+++ b/language/src/vmgc.c
@@ -900,7 +900,8 @@ RING_API void * ring_state_realloc ( void *pState,void *pPointer,size_t nAllocat
 		PoolData *pPoolData  ;
 		PoolDataL2 *pPoolDataL2  ;
 		PoolDataL3 *pPoolDataL3  ;
-		int x, nLevel, nUseMalloc  ;
+		int nLevel, nUseMalloc  ;
+		size_t x  ;
 		nUseMalloc = 0 ;
 		if ( pState != NULL ) {
 			if ( ((RingState *) pState)->pVM != NULL ) {
@@ -943,9 +944,7 @@ RING_API void * ring_state_realloc ( void *pState,void *pPointer,size_t nAllocat
 					/* Allocate new buffer, copy data to it and then free existing pointer from pool */
 					pMemory = ring_state_malloc(pState,nSize);
 					/* Copy existing data */
-					for ( x = 0 ; x < nAllocatedSize ; x++ ) {
-						((unsigned char *) pMemory)[x] = ((unsigned char *) pPointer)[x] ;
-					}
+					RING_MEMCPY(((unsigned char *) pMemory),((unsigned char *) pPointer),nAllocatedSize) ;
 					ring_poolmanager_free(((RingState *) pState),pPointer);
 					return pMemory ;
 				}


### PR DESCRIPTION
The `ring_state_realloc` function previously used a manual, byte-by-byte `for` loop to copy memory when reallocating a block from the pool manager. This can be less performant than using optimized standard library functions for larger memory blocks.

This commit replaces the manual loop with a call to the `RING_MEMCPY` macro. This macro intelligently uses the standard `memcpy` for blocks larger than a defined threshold, which leverages highly-optimized, platform-specific block copy instructions. For very small blocks, it retains a simple loop to avoid function call overhead.

This change improves performance during memory reallocation and promotes code consistency by using a centralized copy utility.

Test suite runs successfully after this change. Ring Notepad and other RingQT applications were also tested successfully.
```
==========================================================================================
 The Report Summary
==========================================================================================
 Tests Count : 806
 PASS        : 806
 FAIL        : 0
==========================================================================================
```