### PR TITLE
Remove manual free() on curl-managed memory to prevent crash

### DIFF
--- a/extensions/ringcurl/libcurl.cf
+++ b/extensions/ringcurl/libcurl.cf
@@ -420,7 +420,6 @@ RING_FUNC(ring_curl_simple_getinfo_1)
 	res = curl_easy_getinfo((CURL *) RING_API_GETCPOINTER(1,"CURL"), (CURLINFO) (int) RING_API_GETNUMBER(2), &sValue);
 	if (res == CURLE_OK && sValue != NULL) {
 		RING_API_RETSTRING(sValue);
-		free(sValue);
 	} else {
 		RING_API_RETSTRING("");
 	}

--- a/extensions/ringcurl/ring_libcurl.c
+++ b/extensions/ringcurl/ring_libcurl.c
@@ -1721,7 +1721,6 @@ RING_FUNC(ring_curl_simple_getinfo_1)
 	res = curl_easy_getinfo((CURL *) RING_API_GETCPOINTER(1,"CURL"), (CURLINFO) (int) RING_API_GETNUMBER(2), &sValue);
 	if (res == CURLE_OK && sValue != NULL) {
 		RING_API_RETSTRING(sValue);
-		free(sValue);
 	} else {
 		RING_API_RETSTRING("");
 	}


### PR DESCRIPTION
According to the official libcurl documentation, memory returned by `curl_easy_getinfo` is owned by the cURL handle and must not be freed by the caller. It is automatically released when `curl_easy_cleanup` is called.

This commit removes the erroneous `free(sValue)` call, which resolves the crash and ensures correct memory management.

Ref: https://curl.se/libcurl/c/curl_easy_getinfo.html