### PR TITLE
Add method to access raw request body

### DIFF
--- a/documents/source/httplib.txt
+++ b/documents/source/httplib.txt
@@ -32,6 +32,7 @@ Server Class Methods
 * cookies() -> aList
 * getFileContent(cFile) -> cString
 * getFileName(cFile) -> cString
+* request().body() -> cString
 
 .. index:: 
 	pair: Using HTTPLib; Example
@@ -402,6 +403,45 @@ Example(2):
 		}	
 
 		oServer.setHTMLPage(oPage)
+
+.. index::
+	pair: Using HTTPLib; Getting the Request Body
+
+Getting the Request Body
+========================
+
+When building APIs, it's common to receive data, like JSON, in the raw body of a POST request. The `oServer["key"]` syntax is for form-data, not raw bodies. To get the raw body, use the `body()` method on the request object.
+
+Example: Receiving JSON Data
+
+.. code-block:: ring
+
+	load "httplib.ring"
+	load "jsonlib.ring"
+
+	? "Start the server..."
+	oServer = new Server
+
+	? `Try: curl -X POST -H "Content-Type: application/json" -d '{"name": "Ring"}' http://localhost:8080/data`
+	oServer.route(:Post, "/data", :process_data)
+
+	? "Listen to port 8080"
+	oServer.listen("0.0.0.0", 8080)
+
+	func process_data
+		// Get the request object
+		oRequest = oServer.request()
+
+		// Get the raw body as a string
+		cBody = oRequest.body()
+
+		? "Received raw body: " + cBody
+
+		// Now you can parse it (e.g., as JSON)
+		aJson = json2list(cBody)
+		cName = aJson["name"]
+
+		oServer.setContent("Hello, " + cName + "!", "text/plain")
 
 .. index:: 
 	pair: Using HTTPLib; More Samples

--- a/extensions/ringhttplib/classes/request.cf
+++ b/extensions/ringhttplib/classes/request.cf
@@ -20,6 +20,7 @@ bool has_file(const char *key)
 MultipartFormData get_file_value(const char *key)
 const char *get_multipartformdata_content2(MultipartFormData *)
 const char *matches(int nIndex)
+const char *body(void)
 </register>
 
 <code>

--- a/extensions/ringhttplib/classes/request.cf
+++ b/extensions/ringhttplib/classes/request.cf
@@ -97,5 +97,19 @@ RING_FUNC(ring_HTTPLib_Request_matches)
 	RING_API_RETSTRING(cString.c_str());
 }
 
+RING_FUNC(ring_HTTPLib_Request_body)
+{
+	Request *pObject;
+	if (RING_API_PARACOUNT != 1) {
+		RING_API_ERROR(RING_API_MISS1PARA);
+		return;
+	}
+	if (!RING_API_ISCPOINTER(1)) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return;
+	}
+	pObject = (Request *)RING_API_GETCPOINTER(1, "HTTPLib_Request");
+	RING_API_RETSTRING2(pObject->body.c_str(), pObject->body.size());
+}
 
 </code>

--- a/extensions/ringhttplib/httplib_classes.ring
+++ b/extensions/ringhttplib/httplib_classes.ring
@@ -103,4 +103,8 @@ class Response from HTTPLib_Response
 
 class Request from HTTPLib_Request
 
+	func body
+			return HTTPLib_Request_body(pObject)
+
+
 class Client from HTTPLib_Client

--- a/extensions/ringhttplib/ring_httplib.cpp
+++ b/extensions/ringhttplib/ring_httplib.cpp
@@ -1497,6 +1497,21 @@ RING_FUNC(ring_HTTPLib_Request_get_multipartformdata_content2)
 	RING_API_RETSTRING2(pMyPointer->content.c_str(),pMyPointer->content.size());
 }
 
+RING_FUNC(ring_HTTPLib_Request_body)
+{
+	Request *pObject;
+	if (RING_API_PARACOUNT != 1) {
+		RING_API_ERROR(RING_API_MISS1PARA);
+		return;
+	}
+	if (!RING_API_ISCPOINTER(1)) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return;
+	}
+	pObject = (Request *)RING_API_GETCPOINTER(1, "HTTPLib_Request");
+	RING_API_RETSTRING2(pObject->body.c_str(), pObject->body.size());
+}
+
 RING_FUNC(ring_HTTPLib_Request_matches)
 {
 	Request *pObject ;
@@ -2539,6 +2554,7 @@ RING_LIBINIT
 	RING_API_REGISTER("httplib_request_get_file_value",ring_HTTPLib_Request_get_file_value);
 	RING_API_REGISTER("httplib_request_get_multipartformdata_content2",ring_HTTPLib_Request_get_multipartformdata_content2);
 	RING_API_REGISTER("httplib_request_matches",ring_HTTPLib_Request_matches);
+	RING_API_REGISTER("httplib_request_body",ring_HTTPLib_Request_body);
 	RING_API_REGISTER("httplib_client_download",ring_HTTPLib_Client_download);
 	RING_API_REGISTER("httplib_client_is_valid",ring_HTTPLib_Client_is_valid);
 	RING_API_REGISTER("httplib_client_is_socket_open",ring_HTTPLib_Client_is_socket_open);

--- a/samples/UsingHTTPLib/test20.ring
+++ b/samples/UsingHTTPLib/test20.ring
@@ -1,0 +1,26 @@
+load "httplib.ring"
+load "jsonlib.ring"
+
+? "Start the server..."
+oServer = new Server
+
+? `Try: curl -X POST -H "Content-Type: application/json" -d '{"name": "Ring"}' http://localhost:8080/data`
+oServer.route(:Post, "/data", :process_data)
+
+? "Listen to port 8080"
+oServer.listen("0.0.0.0", 8080)
+
+func process_data
+	// Get the request object
+	oRequest = oServer.request()
+
+	// Get the raw body as a string
+	cBody = oRequest.body()
+
+	? "Received raw body: " + cBody
+
+	// Now you can parse it (e.g., as JSON)
+	aJson = json2list(cBody)
+	cName = aJson["name"]
+
+	oServer.setContent("Hello, " + cName + "!", "text/plain")


### PR DESCRIPTION
Previously, the library provided convenient access to URL parameters and multipart form data (e.g., `oServer["param"]`). However, there was no direct way to retrieve the raw request body. This made it difficult to handle common API patterns where data is sent as a single payload, such as a `POST` request with a JSON or XML body.

Developers attempting to process a `curl` request like the one below would find it impossible to get the JSON data:
```bash
curl -X POST -H "Content-Type: application/json" -d '{"message":"hello"}' http://localhost:8080/api
```

#### **Solution**

This PR exposes the `body` property from the underlying C++ `httplib::Request` object to the Ring wrapper.

A new method, `body()`, has been added to the `Request` class. Developers can now access the full, raw request body as a string.