### PR TITLE
Add WebSocket and Multi-Interface Support to libcurl Extension

### DIFF
--- a/documents/source/ringlibcurlfuncsdoc.txt
+++ b/documents/source/ringlibcurlfuncsdoc.txt
@@ -213,6 +213,7 @@ Reference
 * CURLE_OK
 * CURLE_UNKNOWN_OPTION
 * CURLE_NOT_BUILT_IN
+* CURLE_AGAIN
 * CURLINFO_EFFECTIVE_URL
 * CURLINFO_RESPONSE_CODE
 * CURLINFO_HTTP_CONNECTCODE
@@ -296,7 +297,32 @@ Reference
 * curl_getContentLengthHeader(CURL *handle)
 * curl_getStartTransferTime(CURL *handle)
 * curl_getPreTransferTime(CURL *handle)
+* CURLM_CALL_MULTI_PERFORM
+* CURLM_OK
+* CURLM_BAD_HANDLE
+* CURLM_BAD_EASY_HANDLE
+* CURLM_OUT_OF_MEMORY
+* CURLM_INTERNAL_ERROR
+* CURLM_BAD_SOCKET
+* CURLM_UNKNOWN_OPTION
+* CURLM_ADDED_ALREADY
+* CURLM_RECURSIVE_API_CALL
+* CURLM_BAD_FUNCTION_ARGUMENT
+* CURLM_ABORTED_BY_CALLBACK
+* CURLM_LAST
+* CURLMSG_DONE
+* CURLOPT_WS_OPTIONS
+* CURLWS_RAW_MODE
+* CURLWS_NOAUTOPONG
+* CURLWS_TEXT
+* CURLWS_BINARY
+* CURLWS_CONT
+* CURLWS_CLOSE
+* CURLWS_PING
+* CURLWS_OFFSET
+* CURLWS_PONG
 * CURLcode curl_global_init(long flags)
+* void curl_global_cleanup(void)
 * CURL *curl_easy_init(void)
 * void curl_easy_cleanup(CURL * handle )
 * CURLcode curl_easy_setopt_1(CURL *handle, CURLoption option, int)
@@ -322,9 +348,19 @@ Reference
 * CURLFORMcode curl_formadd_4(struct curl_httppost **firstitem, struct curl_httppost **lastitem, CURLformoption, const char *, CURLformoption, void *,CURLformoption, long , CURLformoption)
 * CURLFORMcode curl_formadd_5(struct curl_httppost **firstitem, struct curl_httppost **lastitem, CURLformoption, const char *, CURLformoption, void *,CURLformoption, long , CURLformoption, const char* , CURLformoption)
 * CURLFORMcode curl_formadd_6(struct curl_httppost **firstitem, struct curl_httppost **lastitem, CURLformoption, const char *, CURLformoption, const char *,CURLformoption, void * , CURLformoption, long , CURLformoption)
-* CURLFORMcode curl_formadd_7(struct curl_httppost **firstitem, struct curl_httppost **lastitem, CURLformoption, const char *, CURLformoption,  struct curl_forms [], CURLformoption)
+* CURLFORMcode curl_formadd_7(struct curl_httppost **firstitem, struct curl_httppost **lastitem, CURLformoption, const char *, CURLformoption,  struct curl_forms *, CURLformoption)
 * void curl_formfree(struct curl_httppost * form)
 * CURLLIST *curl_slist_append(CURLLIST * list, const char * string )
 * void curl_slist_free_all(CURLLIST * list)
 * char *curl_easy_escape( CURL * curl , const char * string , int length )
 * char *curl_easy_unescape( CURL * curl , const char * url , int inlength , int * outlength )
+* CURLM *curl_multi_init(void)
+* CURLMcode curl_multi_cleanup(CURLM *multi_handle)
+* CURLMcode curl_multi_add_handle(CURLM *multi_handle, CURL *curl_handle)
+* CURLMcode curl_multi_remove_handle(CURLM *multi_handle, CURL *curl_handle)
+* List* curl_multi_perform(CURLM *multi_handle)
+* List* curl_multi_wait(CURLM* multi_handle, double timeout_ms)
+* List* curl_multi_info_read(CURLM *multi_handle)
+* List* curl_ws_send(CURL *curl, const char *buffer, double fragsize, int flags)
+* List* curl_ws_recv(CURL *curl, double buflen)
+* List* curl_ws_meta(CURL *curl)

--- a/extensions/ringcurl/libcurl.cf
+++ b/extensions/ringcurl/libcurl.cf
@@ -243,6 +243,7 @@ CURLOPT_TELNETOPTIONS
 CURLE_OK 
 CURLE_UNKNOWN_OPTION
 CURLE_NOT_BUILT_IN
+CURLE_AGAIN
 
 CURLINFO_EFFECTIVE_URL
 CURLINFO_RESPONSE_CODE
@@ -303,6 +304,32 @@ CURLFORM_BUFFERLENGTH
 CURLFORM_STREAM
 CURLFORM_ARRAY
 CURLFORM_CONTENTHEADER
+
+CURLM_CALL_MULTI_PERFORM
+CURLM_OK
+CURLM_BAD_HANDLE
+CURLM_BAD_EASY_HANDLE
+CURLM_OUT_OF_MEMORY
+CURLM_INTERNAL_ERROR
+CURLM_BAD_SOCKET
+CURLM_UNKNOWN_OPTION
+CURLM_ADDED_ALREADY
+CURLM_RECURSIVE_API_CALL
+CURLM_BAD_FUNCTION_ARGUMENT
+CURLM_ABORTED_BY_CALLBACK
+CURLM_LAST
+CURLMSG_DONE
+
+CURLOPT_WS_OPTIONS
+CURLWS_RAW_MODE
+CURLWS_NOAUTOPONG
+CURLWS_TEXT
+CURLWS_BINARY
+CURLWS_CONT
+CURLWS_CLOSE
+CURLWS_PING
+CURLWS_OFFSET
+CURLWS_PONG
 </constant>
 
 <comment>
@@ -348,6 +375,7 @@ aEnumTypes + "CURLformoption"
 </runcode>
 
 CURLcode curl_global_init(long flags)
+void curl_global_cleanup(void)
 
 CURL *curl_easy_init(void)
 void curl_easy_cleanup(CURL * handle )
@@ -509,5 +537,232 @@ void curl_slist_free_all(CURLLIST * list)
 char *curl_easy_escape( CURL * curl , const char * string , int length )
 char *curl_easy_unescape( CURL * curl , const char * url , int inlength , int * outlength )
 
+<comment>
+Multi Interface
+</comment>
 
+CURLM *curl_multi_init(void)
+CURLMcode curl_multi_cleanup(CURLM *multi_handle)
+CURLMcode curl_multi_add_handle(CURLM *multi_handle, CURL *curl_handle)
+CURLMcode curl_multi_remove_handle(CURLM *multi_handle, CURL *curl_handle)
 
+<code>
+RING_FUNC(ring_curl_multi_perform)
+{
+    CURLM *pMulti;
+    int nRunningHandles = 0;
+    CURLMcode result;
+    List *pList;
+
+    if (RING_API_PARACOUNT != 1 || !RING_API_ISCPOINTER(1)) {
+        RING_API_ERROR(RING_API_BADPARATYPE);
+        return;
+    }
+
+    pMulti = (CURLM *) RING_API_GETCPOINTER(1, "CURLM");
+    if (pMulti == NULL) {
+        RING_API_ERROR(RING_API_NULLPOINTER);
+        return;
+    }
+
+    result = curl_multi_perform(pMulti, &nRunningHandles);
+
+    pList = RING_API_NEWLIST;
+    ring_list_adddouble(pList, (double)result);
+    ring_list_adddouble(pList, (double)nRunningHandles);
+    RING_API_RETLIST(pList);
+}
+
+RING_FUNC(ring_curl_multi_wait)
+{
+    CURLM *pMulti;
+    int nTimeout;
+    int nNumFds = 0;
+    CURLMcode result;
+    List *pList;
+
+    if (RING_API_PARACOUNT != 2 || !RING_API_ISCPOINTER(1) || !RING_API_ISNUMBER(2)) {
+        RING_API_ERROR(RING_API_BADPARATYPE);
+        return;
+    }
+
+    pMulti = (CURLM *) RING_API_GETCPOINTER(1, "CURLM");
+    nTimeout = (int) RING_API_GETNUMBER(2);
+    if (pMulti == NULL) {
+        RING_API_ERROR(RING_API_NULLPOINTER);
+        return;
+    }
+
+    result = curl_multi_wait(pMulti, NULL, 0, nTimeout, &nNumFds);
+
+    pList = RING_API_NEWLIST;
+    ring_list_adddouble(pList, (double)result);
+    ring_list_adddouble(pList, (double)nNumFds);
+    RING_API_RETLIST(pList);
+}
+
+RING_FUNC(ring_curl_multi_info_read)
+{
+    CURLM *pMulti;
+    int nMsgsInQueue = 0;
+    CURLMsg *pMsg;
+    List *pList;
+
+    if (RING_API_PARACOUNT != 1 || !RING_API_ISCPOINTER(1)) {
+        RING_API_ERROR(RING_API_MISS1PARA);
+        return;
+    }
+    
+    pMulti = (CURLM *) RING_API_GETCPOINTER(1, "CURLM");
+    if (pMulti == NULL) {
+        RING_API_ERROR(RING_API_NULLPOINTER);
+        return;
+    }
+
+    pMsg = curl_multi_info_read(pMulti, &nMsgsInQueue);
+    
+    pList = RING_API_NEWLIST;
+
+    if (pMsg) {
+        ring_list_adddouble(pList, (double)pMsg->msg); 
+        ring_list_addcpointer(pList, pMsg->easy_handle, "CURL");
+        ring_list_adddouble(pList, (double)pMsg->data.result);
+    }
+    
+    ring_list_adddouble_gc(((VM *)pPointer)->pRingState, pList, (double)nMsgsInQueue);
+    
+    RING_API_RETLIST(pList);
+}
+</code>
+
+<register>
+List* curl_multi_perform(CURLM *multi_handle)
+List* curl_multi_wait(CURLM* multi_handle, double timeout_ms)
+List* curl_multi_info_read(CURLM *multi_handle)
+</register>
+
+<comment>
+WebSocket
+</comment>
+
+<code>
+/* Helper to convert curl_ws_frame struct to a Ring list */
+static List * ring_curl_ws_frame_to_list(VM *pVM, const struct curl_ws_frame *pFrame)
+{
+    List *pList = ring_vm_api_newlist(pVM);
+    if (pFrame) {
+        ring_list_adddouble_gc(pVM->pRingState, pList, (double)pFrame->age);
+        ring_list_adddouble_gc(pVM->pRingState, pList, (double)pFrame->flags);
+        ring_list_adddouble_gc(pVM->pRingState, pList, (double)pFrame->offset);
+        ring_list_adddouble_gc(pVM->pRingState, pList, (double)pFrame->bytesleft);
+        ring_list_adddouble_gc(pVM->pRingState, pList, (double)pFrame->len);
+    }
+    return pList;
+}
+
+RING_FUNC(ring_curl_ws_send)
+{
+	CURL *pCurl;
+	const void *cBuffer;
+	size_t nBufferLen;
+	size_t nSent;
+	curl_off_t nFragSize;
+	unsigned int nFlags;
+	CURLcode result;
+	List *pList;
+
+	if (RING_API_PARACOUNT != 4) {
+		RING_API_ERROR(RING_API_BADPARACOUNT);
+		return;
+	}
+
+	if (!RING_API_ISCPOINTER(1) || !RING_API_ISSTRING(2) || !RING_API_ISNUMBER(3) || !RING_API_ISNUMBER(4)) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return;
+	}
+	
+	pCurl = (CURL *) RING_API_GETCPOINTER(1, "CURL");
+	cBuffer = (const void *) RING_API_GETSTRING(2);
+	nBufferLen = (size_t) RING_API_GETSTRINGSIZE(2);
+	nFragSize = (curl_off_t) RING_API_GETNUMBER(3);
+	nFlags = (unsigned int) RING_API_GETNUMBER(4);
+	
+	result = curl_ws_send(pCurl, cBuffer, nBufferLen, &nSent, nFragSize, nFlags);
+
+	pList = RING_API_NEWLIST;
+	ring_list_adddouble(pList, (double)result);
+	ring_list_adddouble(pList, (double)nSent);
+	RING_API_RETLIST(pList);
+}
+
+RING_FUNC(ring_curl_ws_recv)
+{
+	CURL *pCurl;
+	char *cBuffer;
+	size_t nBufferLen;
+	size_t nReceived;
+	const struct curl_ws_frame *pMeta;
+	CURLcode result;
+	List *pList, *pMetaList, *pFrameDataList;
+
+	if (RING_API_PARACOUNT != 2) {
+		RING_API_ERROR(RING_API_MISS2PARA);
+		return;
+	}
+	
+	if (!RING_API_ISCPOINTER(1) || !RING_API_ISNUMBER(2)) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return;
+	}
+	
+	pCurl = (CURL *) RING_API_GETCPOINTER(1, "CURL");
+	nBufferLen = (size_t) RING_API_GETNUMBER(2);
+	
+	cBuffer = (char *) RING_API_MALLOC(nBufferLen);
+	if (cBuffer == NULL) {
+		RING_API_ERROR(RING_OOM);
+		return;
+	}
+
+	result = curl_ws_recv(pCurl, cBuffer, nBufferLen, &nReceived, &pMeta);
+	
+	pList = RING_API_NEWLIST;
+	ring_list_adddouble_gc(((VM *)pPointer)->pRingState, pList, (double)result);
+	ring_list_addstring2_gc(((VM *)pPointer)->pRingState, pList, cBuffer, nReceived);
+	ring_list_adddouble_gc(((VM *)pPointer)->pRingState, pList, (double)nReceived);
+	
+	pMetaList = ring_list_newlist_gc(((VM *)pPointer)->pRingState, pList);
+	pFrameDataList = ring_curl_ws_frame_to_list((VM *)pPointer, pMeta);
+	ring_list_copy_gc(((VM *)pPointer)->pRingState, pMetaList, pFrameDataList);
+	
+	RING_API_FREE(cBuffer);
+	RING_API_RETLIST(pList);
+}
+
+RING_FUNC(ring_curl_ws_meta)
+{
+	CURL *pCurl;
+	const struct curl_ws_frame *pMeta;
+
+	if (RING_API_PARACOUNT != 1) {
+		RING_API_ERROR(RING_API_MISS1PARA);
+		return;
+	}
+
+	if (!RING_API_ISCPOINTER(1)) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return;
+	}
+
+	pCurl = (CURL *) RING_API_GETCPOINTER(1, "CURL");
+	pMeta = curl_ws_meta(pCurl);
+	
+	RING_API_RETLIST(ring_curl_ws_frame_to_list((VM *)pPointer, pMeta));
+}
+</code>
+
+<register>
+List* curl_ws_send(CURL *curl, const char *buffer, double fragsize, int flags)
+List* curl_ws_recv(CURL *curl, double buflen)
+List* curl_ws_meta(CURL *curl)
+</register>

--- a/samples/UsingLibCurl/discord_bot/README.md
+++ b/samples/UsingLibCurl/discord_bot/README.md
@@ -1,0 +1,3 @@
+# Simple Discord Bot in Ring
+
+This example demonstrates a basic Discord bot written in the [Ring](https://ring-lang.github.io/) programming language, using cURL.

--- a/samples/UsingLibCurl/discord_bot/bot.ring
+++ b/samples/UsingLibCurl/discord_bot/bot.ring
@@ -1,0 +1,301 @@
+# Discord Bot in Ring using libcurl WebSockets, multi interface, and threads.
+# Connects to Discord Gateway, handles events, and responds to messages.
+# Author: Youssef Saeed (ysdragon) <youssefelkholey@gmail.com>
+
+# Load necessary libraries
+load "libcurl.ring"
+load "stdlibcore.ring"
+load "jsonlib.ring"
+load "threads.ring"
+load "constants.ring"
+
+# Global variables for Discord connection state
+nHeartbeatInterval = 0           # Heartbeat interval (seconds)
+nLastHeartbeatTime = 0           # Last heartbeat timestamp
+nLastSequence = NULL             # Last received sequence number
+lIsConnected = FALSE             # Connection status
+gFrameBuffer = NULL              # Buffer for reassembling fragmented WebSocket frames
+
+#Global Handles and Thread Safety
+pCurl = NULL                     # Main cURL easy handle for WebSocket
+pMulti = NULL                    # cURL multi handle for async operations
+gBotMutex = new_mtx_t()          # Mutex for synchronizing shared state
+
+# Main Bot Logic
+# Entry point: initializes cURL, connects to Discord Gateway, and starts event loop thread.
+func main
+	see "Starting Discord Bot with libcurl.ring and threads..." + nl
+	curl_global_init(CURL_GLOBAL_DEFAULT)     # Initialize cURL library
+	mtx_init(gBotMutex, mtx_plain)            # Initialize mutex for thread safety
+
+	pCurl = curl_easy_init()                  # Create cURL easy handle
+	pMulti = curl_multi_init()                # Create cURL multi handle
+
+	if pCurl = NULL or pMulti = NULL
+		see "Fatal: Could not initialize cURL handles." + nl
+		bye
+	ok
+
+	curl_multi_add_handle(pMulti, pCurl)      # Add easy handle to multi handle
+
+	see "Configuring WebSocket connection to: " + GATEWAY_URL + nl
+	curl_easy_setopt(pCurl, CURLOPT_URL, GATEWAY_URL)         # Set Discord Gateway URL
+	curl_easy_setopt(pCurl, CURLOPT_CONNECT_ONLY, 2)          # Enable connect-only mode for WebSocket
+
+	# Perform the initial connection and handshake with Discord Gateway
+	nStillRunning = 1
+	while nStillRunning > 0
+		aPerformResult = curl_multi_perform(pMulti)
+		if aPerformResult[1] != CURLM_OK
+			see "[FATAL] Handshake perform failed. Code: " + aPerformResult[1] + nl
+			cleanup()
+			bye
+		ok
+		nStillRunning = aPerformResult[2]
+	end
+
+	see "[INFO] WebSocket handshake successful! Waiting for HELLO..." + nl
+	lIsConnected = true
+	
+	# Spawn a thread for the WebSocket event loop (handles all Discord events)
+	see "[INFO] Spawning WebSocket event loop thread..." + nl
+	pThread = new_thrd_t()
+	thrd_create(pThread, websocket_event_loop(pCurl, pMulti))
+
+	nThreadResult = 0
+	thrd_join(pThread, :nThreadResult)        # Wait for event loop thread to finish
+	see "[INFO] Event loop thread has finished." + nl
+
+	cleanup()                                # Clean up resources on exit
+
+# Thread's Main Function: Handles all incoming/outgoing WebSocket traffic and Discord events
+func websocket_event_loop(pCurlPtr, pMultiPtr)
+	# Local copies of cURL handles for this thread
+	pLocalCurl = pCurlPtr
+	pLocalMulti = pMultiPtr
+	 
+	lLocalIsConnected = true
+	 
+	while lLocalIsConnected
+		curl_multi_perform(pLocalMulti)   # Perform async network operations
+
+		# Receive WebSocket data (large buffer for Discord frames)
+		aRecvData = curl_ws_recv(pLocalCurl, 65536)
+		nRecvResult = aRecvData[1]
+
+		if nRecvResult = CURLE_OK
+			# Append received chunk to the global buffer (thread-safe)
+			mtx_lock(gBotMutex)
+			gFrameBuffer += aRecvData[2]
+			mtx_unlock(gBotMutex)
+			
+			pMeta = aRecvData[4]
+			nBytesLeft = pMeta[4]
+
+			# Only process the frame if it's complete (bytesleft is 0)
+			if nBytesLeft = 0
+				mtx_lock(gBotMutex)
+				cPayloadToProcess = gFrameBuffer
+				gFrameBuffer = "" # Clear buffer for next message
+				mtx_unlock(gBotMutex)
+
+				if len(cPayloadToProcess) > 0
+					handle_gateway_frame(pLocalCurl, cPayloadToProcess)  # Parse and handle Discord event
+				ok
+			ok
+		but nRecvResult != CURLE_AGAIN
+			# Connection error: mark as disconnected and exit loop
+			see "[FATAL] Main loop connection error. Code: " + nRecvResult + nl
+			mtx_lock(gBotMutex)
+			lIsConnected = false
+			mtx_unlock(gBotMutex)
+		ok
+		
+		check_multi_messages(pLocalMulti)  # Check for completed transfers/errors
+
+		# Heartbeat logic: send heartbeat at required interval
+		mtx_lock(gBotMutex)
+		if lIsConnected and nHeartbeatInterval > 0 and (epochtime(date(), time()) - nLastHeartbeatTime) >= nHeartbeatInterval
+			mtx_unlock(gBotMutex)
+			send_heartbeat(pLocalCurl)
+		else
+			mtx_unlock(gBotMutex)
+		ok
+		
+		curl_multi_wait(pLocalMulti, 100)  # Wait for network events
+		
+		# Update local connection status from global state
+		mtx_lock(gBotMutex)
+		lLocalIsConnected = lIsConnected
+		mtx_unlock(gBotMutex)
+	end
+	
+	see "[THREAD] Exiting event loop." + nl
+	thrd_exit(0)
+
+
+# Helper Functions
+
+# Cleanup resources and handles before exiting
+func cleanup()
+	see "Bot shutting down." + nl
+	if pMulti != NULL and pCurl != NULL
+		curl_multi_remove_handle(pMulti, pCurl)
+	ok
+	if pCurl != NULL
+		curl_easy_cleanup(pCurl) 
+	ok
+	if pMulti != NULL
+		curl_multi_cleanup(pMulti)
+	ok
+	curl_global_cleanup()
+	mtx_destroy(gBotMutex)
+
+
+# Check for completed cURL transfers and handle errors
+func check_multi_messages(pMulti)
+	while true
+		aMessage = curl_multi_info_read(pMulti)
+		if len(aMessage) <= 1
+			break
+		ok
+		if aMessage[1] = CURLMSG_DONE and aMessage[3] != CURLE_OK
+			see "[FATAL] Unexpected termination. CURLcode: " + aMessage[3] + nl
+			mtx_lock(gBotMutex) 
+			lIsConnected = false
+			mtx_unlock(gBotMutex)
+		ok
+	end
+
+# Parse and handle a single Discord Gateway frame (JSON event)
+func handle_gateway_frame(pCurl, cJsonPayload)
+	try
+		aPayload = json2list(cJsonPayload)
+	catch
+		see "[WARN] Failed to parse JSON: " + cJsonPayload + nl
+		return
+	done
+
+	# Update sequence number and extract opcode
+	mtx_lock(gBotMutex)
+	if isnumber(aPayload["s"])
+		nLastSequence = aPayload["s"]
+	ok
+	nOpcode = aPayload["op"]
+	mtx_unlock(gBotMutex)
+
+	# Handle Discord Gateway opcodes/events
+	switch nOpcode
+		on DISCORD_OP_HELLO
+			# Received HELLO: set heartbeat interval and identify
+			mtx_lock(gBotMutex)
+			nHeartbeatInterval = number(aPayload[:d][:heartbeat_interval]) / 1000
+			mtx_unlock(gBotMutex)
+			see "[INFO] Received HELLO. Heartbeat interval: " + nHeartbeatInterval + " seconds." + nl
+			identify(pCurl)
+			send_heartbeat(pCurl)
+
+		on DISCORD_OP_HEARTBEAT_ACK
+			# Heartbeat acknowledged by Discord
+			see "[DEBUG] Heartbeat Acknowledged." + nl
+
+		on DISCORD_OP_DISPATCH
+			# Handle specific Discord events (READY, MESSAGE_CREATE, etc.)
+			cEventName = aPayload["t"]
+			aEventData = aPayload["d"]
+			if cEventName = "READY"
+				see "[INFO] Bot is READY! Logged in as: " + aEventData["user"]["username"] + nl
+			but cEventName = "MESSAGE_CREATE"
+				handle_message_create(pCurl, aEventData)
+			ok
+			
+		on DISCORD_OP_RECONNECT
+			# Discord requests reconnect: mark as disconnected
+			see "[INFO] Server requested reconnect. Closing connection." + nl
+			mtx_lock(gBotMutex)
+			lIsConnected = false
+			mtx_unlock(gBotMutex)
+	off
+
+# Send a heartbeat frame to Discord Gateway to keep the connection alive
+func send_heartbeat(pCurl)
+	mtx_lock(gBotMutex)
+	nLastHeartbeatTime = epochtime(date(), time())
+	cPayload = list2json([ :op = DISCORD_OP_HEARTBEAT, :d = nLastSequence ])
+	mtx_unlock(gBotMutex)
+	
+	see "[INFO] Sending Heartbeat (Sequence: " + nLastSequence + ")..." + nl
+	aResult = curl_ws_send(pCurl, cPayload, 0, CURLWS_TEXT)
+	if aResult[1] != CURLE_OK
+		see "[WARN] Failed to send heartbeat." + nl
+	ok
+
+# Send IDENTIFY payload to Discord to authenticate the bot session
+func identify(pCurl)
+	see "[INFO] Sending IDENTIFY payload..." + nl
+	aPayload = [
+		:op = DISCORD_OP_IDENTIFY,
+		:d = [ 
+			:token = BOT_TOKEN,
+			:intents = 33281,
+			:properties = [ :os = "linux", :browser = "ring-libcurl", :device = "ring-libcurl" ] 
+		]
+	]
+	aResult = curl_ws_send(pCurl, list2json(aPayload), 0, CURLWS_TEXT)
+	if aResult[1] != CURLE_OK
+		see "[WARN] Failed to send identify payload." + nl
+	ok
+
+# Handle a MESSAGE_CREATE event from Discord (respond to user messages)
+func handle_message_create(pCurl, aMessage)
+	# Ignore messages from bots (including itself) or commands not starting with '!'
+	if islist(aMessage["author"]) and not isNull(aMessage["author"]["bot"]) or substr(aMessage["content"], 1, 1) != "!"
+		return
+	ok
+
+	cContent = aMessage["content"]
+	cChannelId = aMessage["channel_id"]
+	cAuthorId = aMessage["author"]["id"]
+	
+	switch cContent
+		on "!hello"
+			see "[COMMAND] Received !hello from " + aMessage["author"]["username"] + nl
+			send_reply(cChannelId, cAuthorId, "Hello from a Ring bot!")
+		on "!ring"
+			see "[COMMAND] Received !ring from " + aMessage["author"]["username"] + nl
+			cMessage = "Hello, I'm a bot made with Ring!\nRing is awesome!"
+			send_reply(cChannelId, cAuthorId, cMessage)
+		on "!version"
+			see "[COMMAND] Received !version from " + aMessage["author"]["username"] + nl
+			cVersion = "Ring version: " + version(1)
+			send_reply(cChannelId, cAuthorId, cVersion)
+		other
+			send_reply(cChannelId, cAuthorId, "Unknown command!")
+			see "[COMMAND] Unrecognized command: " + cContent + " from " + aMessage["author"]["username"] + nl
+	off
+
+# Send a reply message to a Discord channel, mentioning the user
+func send_reply(cChannelId, cUserId, cMessage)
+	see "[ACTION] Sending reply to user " + cUserId + " in channel " + cChannelId + nl
+	pCurlSend = curl_easy_init()
+	cUrl = "https://discord.com/api/v10/channels/" + cChannelId + "/messages"
+	cAuth = "Authorization: Bot " + BOT_TOKEN
+	cType = "Content-Type: application/json"
+	aHeaders = curl_slist_append(NULL, cAuth)
+	aHeaders = curl_slist_append(aHeaders, cType)
+	cMention = "<@" + cUserId + ">"
+	cBody = list2json([
+		:content = cMention + " " + cMessage,
+		:allowed_mentions = [:parse = [],
+			:users = [
+				cUserId
+			]
+		]
+	])
+	curl_easy_setopt(pCurlSend, CURLOPT_URL, cUrl)
+	curl_easy_setopt(pCurlSend, CURLOPT_HTTPHEADER, aHeaders)
+	curl_easy_setopt(pCurlSend, CURLOPT_POST, 1)
+	curl_easy_setopt(pCurlSend, CURLOPT_POSTFIELDS, cBody)
+	curl_easy_setopt(pCurlSend, CURLOPT_TIMEOUT, 10)
+	curl_easy_perform_silent(pCurlSend)
+	curl_easy_cleanup(pCurlSend)

--- a/samples/UsingLibCurl/discord_bot/constants.ring
+++ b/samples/UsingLibCurl/discord_bot/constants.ring
@@ -1,0 +1,11 @@
+# Configuration
+BOT_TOKEN = "DISCORD_BOT_TOKEN"
+GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json"
+
+# Discord Gateway Opcodes
+DISCORD_OP_DISPATCH = 0
+DISCORD_OP_HEARTBEAT = 1
+DISCORD_OP_IDENTIFY = 2
+DISCORD_OP_HELLO = 10
+DISCORD_OP_HEARTBEAT_ACK = 11
+DISCORD_OP_RECONNECT = 7

--- a/samples/UsingLibCurl/t12.ring
+++ b/samples/UsingLibCurl/t12.ring
@@ -1,0 +1,51 @@
+load "libcurl.ring"
+
+global_init = curl_global_init(CURL_GLOBAL_DEFAULT)
+
+if global_init = 0
+	see "curl_global_init() failed" + nl
+	bye
+ok
+
+multi_handle = curl_multi_init()
+
+if multi_handle = NULL
+	see "curl_multi_init() failed" + nl
+	bye
+ok
+
+easy_handle1 = curl_easy_init()
+easy_handle2 = curl_easy_init()
+easy_handle3 = curl_easy_init()
+
+curl_easy_setopt_2(easy_handle1, CURLOPT_URL, "http://ip-api.com/json/")
+curl_easy_setopt_2(easy_handle2, CURLOPT_URL, "https://api.ipapi.is/")
+curl_easy_setopt_2(easy_handle3, CURLOPT_URL, "https://api.ipquery.io/")
+
+curl_multi_add_handle(multi_handle, easy_handle1)
+curl_multi_add_handle(multi_handle, easy_handle2)
+curl_multi_add_handle(multi_handle, easy_handle3)
+
+running_handles = 1
+
+while running_handles > 0
+	multi_perform_result = curl_multi_perform(multi_handle)
+	running_handles = multi_perform_result[2]
+	if running_handles > 0
+		curl_multi_wait(multi_handle, 1000)
+	ok
+end
+
+curl_multi_remove_handle(multi_handle, easy_handle1)
+curl_multi_remove_handle(multi_handle, easy_handle2)
+curl_multi_remove_handle(multi_handle, easy_handle3)
+
+curl_easy_cleanup(easy_handle1)
+curl_easy_cleanup(easy_handle2)
+curl_easy_cleanup(easy_handle3)
+
+curl_multi_cleanup(multi_handle)
+
+curl_global_cleanup()
+
+? nl + "Multi Perform test completed successfully!" + nl

--- a/samples/UsingLibCurl/t13.ring
+++ b/samples/UsingLibCurl/t13.ring
@@ -1,0 +1,41 @@
+load "libcurl.ring"
+
+global_init = curl_global_init(CURL_GLOBAL_DEFAULT)
+
+if global_init = 0
+	see "curl_global_init() failed" + nl
+	bye
+ok
+
+easy_handle = curl_easy_init()
+
+if easy_handle = NULL
+	see "curl_easy_init() failed" + nl
+	bye
+ok
+
+curl_easy_setopt_2(easy_handle, CURLOPT_URL, "wss://echo.websocket.events")
+curl_easy_setopt_1(easy_handle, CURLOPT_CONNECT_ONLY, 2)
+
+curl_easy_perform(easy_handle)
+
+see "WebSocket connection established." + nl
+
+sent_result = curl_ws_send(easy_handle, "Hello, Ring!", 0, CURLWS_TEXT)
+if sent_result[1] != CURLE_OK
+	see "curl_ws_send() failed" + nl
+else
+	see "Sent 'Hello, Ring!' to the server." + nl
+ok
+
+recv_result = curl_ws_recv(easy_handle, 1024)
+if recv_result[1] != CURLE_OK and recv_result[1] != CURLE_AGAIN
+	see "curl_ws_recv() failed" + nl
+else
+	see "Received: " + recv_result[2] + nl
+ok
+
+curl_easy_cleanup(easy_handle)
+curl_global_cleanup()
+
+see "WebSocket test completed successfully!" + nl


### PR DESCRIPTION
This pull request introduces comprehensive WebSocket client functionality and adds multi-interface capabilities to the Ring libcurl extension. These enhancements enable Ring applications to establish and manage WebSocket connections, as well as perform multiple transfers in parallel.

### Key Additions:

- WebSocket: `curl_ws_send`, `curl_ws_recv`, `curl_ws_meta`
- Multi-interface: `curl_multi_init`, `curl_multi_cleanup`, `curl_multi_add_handle`, `curl_multi_remove_handle`, `curl_multi_perform`, `curl_multi_wait`, `curl_multi_info_read`
- Global: `curl_global_cleanup`
- New constants for WebSocket and multi-interface operations
- Examples: `t12.ring` (multi), `t13.ring` (WebSocket), `discord_bot` (Discord bot demo)

I don't know if `samples/UsingLibCurl` is the best place for the Discord demo.