### PR TITLE
Adjust `fgets()` return string size to actual length read

### DIFF
--- a/language/src/file_e.c
+++ b/language/src/file_e.c
@@ -323,7 +323,7 @@ void ring_vm_file_fgetc(void *pPointer) {
 
 void ring_vm_file_fgets(void *pPointer) {
 	char *cStr;
-	int nSize;
+	int nSize, nResult;
 	FILE *pFile;
 	char *cResult;
 	if (RING_API_PARACOUNT != 2) {
@@ -344,6 +344,9 @@ void ring_vm_file_fgets(void *pPointer) {
 			cResult = fgets(cStr, nSize, pFile);
 			if (cResult == NULL) {
 				RING_API_RETNUMBER(0);
+			} else {
+				nResult = strlen(cStr);
+				(RING_API_GETSTRINGRAW)->nSize = nResult;
 			}
 		}
 	} else {


### PR DESCRIPTION
Similar to the `fread()` fix, this prevents returning garbage data at the end of the buffer.