### PR TITLE
Update libraries/csvlib: Correct syntax for not-equals operator

### DIFF
--- a/libraries/csvlib/csvlib.ring
+++ b/libraries/csvlib/csvlib.ring
@@ -90,14 +90,14 @@ func List2CSV_Process aList,nStart
 				}
 			}
 		elseif isList(item)
-			if nStart! = 0 { 
+			if nStart != 0 { 
 				cOutput += nl
 			} 
 			cOutput += List2CSV_Process(item,nStart+1)
 		}
 		nIndex++
 	}
-	if nStart! = 0 { 
+	if nStart != 0 { 
 		cOutput += nl
 	} 
 	return cOutput 


### PR DESCRIPTION
Hello Mahmoud,

This PR fixes a syntax error where the not-equals operator was written as `! =` instead of `!=`.

As I mentioned, I noticed this was causing errors when I was testing the nightly Ring Docker image.

Best regards,
Youssef