### PR TITLE
Tests: fix wrong expected output of general_fread test by removing erroneous new lines

### DIFF
--- a/language/tests/correct/general_fread.txt
+++ b/language/tests/correct/general_fread.txt
@@ -1,8 +1,8 @@
-Size: 125
-fp = fopen(filename(),"rb")
-
-cData = fread(fp,1000)
-? "Size: " + len(cData)
-? cData
-
+Size: 119
+fp = fopen(filename(),"rb")
+
+cData = fread(fp,1000)
+? "Size: " + len(cData)
+? cData
+
 fclose(fp)	# Not necessary in Ring


### PR DESCRIPTION
The expected output of general\fread.ring test was wrong because it had erroneous new lines added to it. This made the test appear as failing although it was succeeding. This commit removes the erroneous new lines so that the output matches the content of original fread.ring file as stored in git repository (fread.ring is stored in the repository with Unix line ending and UTF-8 encoding).