### PR TITLE
perf(hashtable): replace modulo with bitwise AND for bucket indexing

### DIFF
--- a/language/src/rhtable.c
+++ b/language/src/rhtable.c
@@ -19,7 +19,8 @@ RING_API unsigned int ring_hashtable_hashkey_gc(void *pRingState, HashTable *pHa
 #else
 	nIndex = ring_hashlib_murmurthree32((const char *)cKey, strlen(cKey), RING_HASHTABLE_HASHFUNCSEED);
 #endif
-	nIndex = nIndex % pHashTable->nLinkedLists;
+	/* nLinkedLists is always a power of two (starts at 2 and doubles). Use bit mask instead of modulo for speed. */
+	nIndex = nIndex & (pHashTable->nLinkedLists - 1);
 	return nIndex;
 }
 


### PR DESCRIPTION
Replace `nIndex % nLinkedLists` with `nIndex & (nLinkedLists - 1)` in `ring_hashtable_hashkey_gc`. `nLinkedLists` starts at 2 and always doubles, so it remains a power of two. The bitwise mask avoids a division instruction and offers a small performance improvement. It doesn't introduce any functional changes.