### PR TITLE
build(locatevc.bat): avoid re-running vcvars/VsDevCmd and prevent PATH bloat

### DIFF
--- a/language/build/locatevc.bat
+++ b/language/build/locatevc.bat
@@ -11,6 +11,25 @@ set ringldflags=
 set ringdebug=0
 set ringsubsystem=5.01
 
+rem compute requested target and short-circuit if already initialized 
+rem requested target is either first arg or second arg when first is "auto"
+set "REQUEST_TARGET=%~1"
+if /I "%REQUEST_TARGET%"=="auto" (
+    if not "%~2"=="" set "REQUEST_TARGET=%~2"
+)
+if "%REQUEST_TARGET%"=="" set "REQUEST_TARGET=x86"
+
+if defined RING_VCVARS_INITIALIZED (
+    if /I "%REQUEST_TARGET%"=="auto" (
+        REM already initialized for some arch so skip re-initialization
+        exit /b
+    ) else (
+        if /I "%RING_VCVARS_TARGET%"=="%REQUEST_TARGET%" (
+            REM already initialized for the requested arch so skip
+            exit /b
+        )
+    )
+)
 
 if /I ["%1"]==["x64"] (
 	set ringbuildtarget=x64
@@ -58,128 +77,166 @@ if %ringdebug% EQU 1 (
 )
 
 if exist "C:\Program Files\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" (
-	call "C:\Program Files\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" %ringbuildtarget%
-	exit /b
+    call "C:\Program Files\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" %ringbuildtarget%
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" (
-	call "C:\Program Files\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" %ringbuildtarget%
-	exit /b
+    call "C:\Program Files\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" %ringbuildtarget%
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" (
-	call "C:\Program Files\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %ringbuildtarget%
-	exit /b
+    call "C:\Program Files\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %ringbuildtarget%
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%" 
-	call "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd   
-	exit /b
+    pushd "%cd%" 
+    call "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd   
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%"
-	call "C:\Program Files\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd
-	exit /b
+    pushd "%cd%"
+    call "C:\Program Files\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%"
-	call "C:\Program Files\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd
-	exit /b
+    pushd "%cd%"
+    call "C:\Program Files\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%"
-	call "C:\Program Files\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd
-	exit /b
+    pushd "%cd%"
+    call "C:\Program Files\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%"
-	call "C:\Program Files\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd
-	exit /b
+    pushd "%cd%"
+    call "C:\Program Files\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%"
-	call "C:\Program Files\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd
-	exit /b
+    pushd "%cd%"
+    call "C:\Program Files\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files\Microsoft Visual Studio\2019\Professional\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%"
-	call "C:\Program Files\Microsoft Visual Studio\2019\Professional\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd
-	exit /b
+    pushd "%cd%"
+    call "C:\Program Files\Microsoft Visual Studio\2019\Professional\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%"
-	call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd
-	exit /b
+    pushd "%cd%"
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%"
-	call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd
-	exit /b
+    pushd "%cd%"
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%"
-	call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd
-	exit /b
+    pushd "%cd%"
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%"
-	call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd
-	exit /b
+    pushd "%cd%"
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%"
-	call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd
-	exit /b
+    pushd "%cd%"
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%"
-	call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd
-	exit /b
+    pushd "%cd%"
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files (x86)\Microsoft Visual Studio 10.0\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%"
-	call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd
-	exit /b
+    pushd "%cd%"
+    call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%"
-	call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd
-	exit /b
+    pushd "%cd%"
+    call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )
 
 if exist "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat" (
-	pushd "%cd%"
-	call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
-	popd
-	exit /b
+    pushd "%cd%"
+    call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat" -arch=%ringbuildtarget%
+    popd
+    set RING_VCVARS_INITIALIZED=1
+    set RING_VCVARS_TARGET=%ringbuildtarget%
+    exit /b
 )


### PR DESCRIPTION
Add an initialization guard (`RING_VCVARS_INITIALIZED`/`RING_VCVARS_TARGET`) so `locatevc.bat` skips repeated Visual Studio env setup for the same requested arch (treats "auto" as satisfied if already initialized). Sets the guard after successful vcvars/VsDevCmd calls.

This fixes a build failure ("The input line is too long. The syntax of the command is incorrect.") caused by PATH growth when building with `build\buildvc_x64.bat` on machines with long initial PATH.

Example of failure is below:
```
Building Ring (64bit) for Windows...
Building Compiler/VM...
Building Extensions...
Building RingAllegro...
Building RingOpenGL...
Building RingCJSON...
Building RingConsoleColors...
Building RingFreeGLUT...
Building RingStbImage...
Building RingThreads...
Building RingRayLib...
Building RingQt (Core)...
Building RingQt (LightGUILib)...
Building RingQt (GUILib)...
File not found - plugins
File not found - qml
File not found - translations
File not found - resources
Building RingLibuv...
Building RingInternet...
Building RingCurl...
Building RingOpenSSL...
Building RingLibui...
Building RingBeep...
Building RingODBC...
Building RingHTTPLib...
Building RingMouseEvent...
Building RingMurmurHash...
Building RingSockets...
Building RingSQLite...
Building RingZip...
Building RingWinAPI...
Building RingWinCREG...
Building RingWinLib...
Building RingTilengine...
Building RingLibSDL...
Building RingMySQL...
Building RingPostgreSQL...
Building RingRogueUtil...
Building RingPDFGen...
Building RingFastPro...
Building Tools...
Building Ring2EXE...
Building RingPM...
Building RingREPL...
Building RingFmt...
Building Folder2Qrc...
Building Tests...
Building Extensions\Tutorial...
The input line is too long.
The syntax of the command is incorrect.
```