### PR TITLE
Update StdLIb - Rename `fflush` function to `std_fflush`

### DIFF
--- a/libraries/stdlib/stdfunctions.ring
+++ b/libraries/stdlib/stdfunctions.ring
@@ -179,7 +179,7 @@ Func std_fopen cFileName,cMode
 Func std_fclose filehandle
 	fclose(filehandle)
 
-Func fflush filehandle
+Func std_fflush filehandle
 	fflush(filehandle)
 
 Func std_freopen cFileName,cMode,FileHandle


### PR DESCRIPTION
This fixes an issue when using `fflush` in a script that loads `stdlibcore.ring` or `stdlib.ring` (which caused a Stack Overflow).

Also, this aligns with `stdfile.ring`, which calls `std_fflush` (a function that didn't exist previously).

Thanks!