### PR TITLE
Update extensions/ringsdl/buildgcc.sh - Remove incorrect SDL2_gfx flags from `pkg-config`

### DIFF
--- a/extensions/ringsdl/buildgcc.sh
+++ b/extensions/ringsdl/buildgcc.sh
@@ -1,3 +1,3 @@
-gcc -c -fpic -O2 ring_libsdl.c -I $PWD/../../language/include -I /usr/include/SDL2
-gcc -shared -o $PWD/../../lib/libringsdl.so ring_libsdl.o -L $PWD/../../lib -lring `pkg-config --cflags --libs sdl2 SDL2_ttf SDL2_image SDL2_mixer SDL2_net SDL2_gfx`
-[ -f ring_libsdl.o ] && rm ring_libsdl.o
+gcc -c -fpic -O2 ring_libsdl.c -I $PWD/../../language/include $(pkg-config --cflags sdl2 SDL2_ttf SDL2_image SDL2_mixer SDL2_net)
+
+gcc -shared -o $PWD/../../lib/libringsdl.so ring_libsdl.o -L $PWD/../../lib -lring $(pkg-config --libs sdl2 SDL2_ttf SDL2_image SDL2_mixer SDL2_net)


### PR DESCRIPTION
Hello Mahmoud,

This pull request corrects the pkg-config configuration in `extensions/ringsdl/buildgcc.sh`.

In the previous PR, `SDL2_gfx` was incorrectly added to the `pkg-config --cflags/--libs` commands, which caused the build process to fail on Ubuntu.

This update fixes that configuration to ensure a successful build.

Best regards,
Youssef