### PR TITLE
Update RingPM Registry - Add Ring CFFI

### DIFF
--- a/tools/ringpm/registry/registry.ring
+++ b/tools/ringpm/registry/registry.ring
@@ -966,5 +966,9 @@ aPackagesRegistry = [
 	[ :name = "solitaire",
 	  :description = "The Solitaire game developed using Ring and RingRayLib",
 	  :ProviderUserName = "ringpackages"
+	],
+	[ :name = "ring-cffi",
+	  :description = "Foreign Function Interface (FFI) for the Ring programming language",
+	  :ProviderUserName = "ysdragon"
 	]
 ]


### PR DESCRIPTION
Hello Mahmoud,

I've opened this PR to add ring-cffi to the RingPM registry. This is a new Foreign Function Interface (FFI) extension that allows users to interact with C libraries natively without writing any C code.

While it is still experimental, I believe it is already a very useful addition to the Ring ecosystem.

Repo and documentation: [ring-cffi - GitHub](https://github.com/ysdragon/ring-cffi)

Best regards,
Youssef