### PR TITLE
Update language/src/vmoop.c - ring_vm_oop_parentmethods() ISPARENTINFO fix

### DIFF
--- a/language/src/vmoop.c
+++ b/language/src/vmoop.c
@@ -515,7 +515,7 @@ void ring_vm_oop_parentmethods(VM *pVM, List *pList) {
 				break;
 			}
 			/* Exit when the parent class already contains it's parent classes data */
-			if (ring_list_getint(pList, RING_CLASSMAP_ISPARENTINFO) == 1) {
+			if (ring_list_getint(pList4, RING_CLASSMAP_ISPARENTINFO) == 1) {
 				break;
 			}
 		}


### PR DESCRIPTION
## Summary

Fix `ring_vm_oop_parentmethods()` to read `RING_CLASSMAP_ISPARENTINFO` from the resolved parent class map (`pList4`) while walking the inheritance chain, instead of incorrectly using the child class list (`pList`) passed into the function.

## Context

This matches the comment at the call site: the check should decide whether the **parent** class already has parent metadata populated, not the original child list.

## Commit

Same title/body as the single commit on this branch.