### PR TITLE
Update language/src/genlib_e.c - list2str() newline guard uses nStart

### DIFF
--- a/language/src/genlib_e.c
+++ b/language/src/genlib_e.c
@@ -616,12 +616,12 @@ void ring_vm_generallib_list2str(void *pPointer) {
 	pString = ring_string_new_gc(((VM *)pPointer)->pRingState, RING_CSTR_EMPTY);
 	for (x = nStart; x <= nMax; x++) {
 		if (ring_list_isstring(pList, x)) {
-			if (x != 1) {
+			if (x != nStart) {
 				ring_string_add_gc(((VM *)pPointer)->pRingState, pString, "\n");
 			}
 			ring_string_add_gc(((VM *)pPointer)->pRingState, pString, ring_list_getstring(pList, x));
 		} else if (ring_list_isnumber(pList, x)) {
-			if (x != 1) {
+			if (x != nStart) {
 				ring_string_add_gc(((VM *)pPointer)->pRingState, pString, "\n");
 			}
 			ring_vm_numtostring((VM *)pPointer, ring_list_getdouble(pList, x), cStr);


### PR DESCRIPTION
## Summary

In `ring_vm_generallib_list2str()`, newline separators between list items were skipped using `x != 1`. The function iterates `x` from `nStart` to `nMax`, so when `nStart > 1` the first emitted item incorrectly received a leading newline.

## Change

Use `x != nStart` for both string and number branches so the first **included** index never gets a prefix newline.

## Note

Local build artifacts were not committed.