### PR TITLE
Update language/src/genlib_e.c - lines() count for empty string and trailing newline

### DIFF
--- a/language/src/genlib_e.c
+++ b/language/src/genlib_e.c
@@ -1056,9 +1056,9 @@ void ring_vm_generallib_lines(void *pPointer) {
 	if (RING_API_ISSTRING(1)) {
 		cStr = RING_API_GETSTRING(1);
 		nSize = RING_API_GETSTRINGSIZE(1);
-		nCount = 1;
+		nCount = (nSize > 0) ? 1 : 0;
 		for (x = 0; x < nSize; x++) {
-			if (cStr[x] == '\n') {
+			if (cStr[x] == '\n' && x != nSize - 1) {
 				nCount++;
 			}
 		}


### PR DESCRIPTION
## Summary

Adjust `ring_vm_generallib_lines()` when the argument is a string:

- **Empty string** (`nSize == 0`): return **0** lines (previously returned 1).
- **Trailing newline**: do not increment the line count for a `\n` at the last index, so a string ending with one newline matches “lines separated by \n” without an implicit empty trailing line.

## Files

- `language/src/genlib_e.c` only (no build artifacts).