### PR TITLE
Update language/src/ringapi.c - getcpointer2pointer() typed null handling

### DIFF
--- a/language/src/ringapi.c
+++ b/language/src/ringapi.c
@@ -374,7 +374,8 @@ RING_API void *ring_vm_api_getcpointer2pointer(void *pPointer, int nPara, const 
 				RING_API_ERROR(RING_API_BADPARATYPE);
 				return NULL;
 			} else {
-				if (strcmp(ring_list_getstring(pList, RING_CPOINTER_TYPE), "NULLPOINTER") == 0) {
+				if (strcmp(ring_list_getstring(pList, RING_CPOINTER_TYPE), "NULLPOINTER") == 0 ||
+				    strcmp(ring_list_getstring(pList, RING_CPOINTER_TYPE), cType) == 0) {
 					return NULL;
 				}
 			}


### PR DESCRIPTION
## Summary

In `ring_vm_api_getcpointer2pointer()`, when the list’s native pointer is `NULL`, the VM only skipped the error path if `RING_CPOINTER_TYPE` was the literal `"NULLPOINTER"`. Extensions that keep the real type name on a null optional pointer were still hitting `RING_API_NULLPOINTER`.

## Change

Also return `NULL` without error when the stored type string equals the requested `cType` (typed null), same outcome as the `NULLPOINTER` sentinel.

## Scope

- `language/src/ringapi.c` only; build artifacts not committed.