### PR TITLE
Update RingStbImage - Use channels_in_file when desired_channels is 0 in `stbi_load` functions

### DIFF
--- a/extensions/ringstbimage/ring_stbimage.c
+++ b/extensions/ringstbimage/ring_stbimage.c
@@ -75,7 +75,7 @@ RING_FUNC(ring_stbi_load_from_memory)
 		RING_API_RETSTRING("") ;
 		return ;
 	}
-	RING_API_RETSTRING2(pData, (*p1) * (*p2) * nChannels);
+	RING_API_RETSTRING2(pData, (*p1) * (*p2) * (nChannels ? nChannels : *p3));
 	stbi_image_free(pData);
 	RING_API_ACCEPTINTVALUE(3) ;
 	RING_API_ACCEPTINTVALUE(4) ;
@@ -120,7 +120,7 @@ RING_FUNC(ring_stbi_load)
 		RING_API_RETSTRING("") ;
 		return ;
 	}
-	RING_API_RETSTRING2(pData, (*p1) * (*p2) * nChannels);
+	RING_API_RETSTRING2(pData, (*p1) * (*p2) * (nChannels ? nChannels : *p3));
 	stbi_image_free(pData);
 	RING_API_ACCEPTINTVALUE(2) ;
 	RING_API_ACCEPTINTVALUE(3) ;
@@ -161,7 +161,7 @@ RING_FUNC(ring_stbi_load_from_file)
 	p3 = RING_API_GETINTPOINTER(4);
 	nChannels = (int) RING_API_GETNUMBER(5);
 	pData = stbi_load_from_file((FILE *) RING_API_GETCPOINTER(1,"FILE"),p1,p2,p3,nChannels) ;
-	RING_API_RETSTRING2(pData, (*p1) * (*p2) * nChannels);
+	RING_API_RETSTRING2(pData, (*p1) * (*p2) * (nChannels ? nChannels : *p3));
 	stbi_image_free(pData);
 	RING_API_ACCEPTINTVALUE(2) ;
 	RING_API_ACCEPTINTVALUE(3) ;

--- a/extensions/ringstbimage/stbimage.cf
+++ b/extensions/ringstbimage/stbimage.cf
@@ -78,7 +78,7 @@ RING_FUNC(ring_stbi_load_from_memory)
 		RING_API_RETSTRING("") ;
 		return ;
 	}
-	RING_API_RETSTRING2(pData, (*p1) * (*p2) * nChannels);
+	RING_API_RETSTRING2(pData, (*p1) * (*p2) * (nChannels ? nChannels : *p3));
 	stbi_image_free(pData);
 	RING_API_ACCEPTINTVALUE(3) ;
 	RING_API_ACCEPTINTVALUE(4) ;
@@ -123,7 +123,7 @@ RING_FUNC(ring_stbi_load)
 		RING_API_RETSTRING("") ;
 		return ;
 	}
-	RING_API_RETSTRING2(pData, (*p1) * (*p2) * nChannels);
+	RING_API_RETSTRING2(pData, (*p1) * (*p2) * (nChannels ? nChannels : *p3));
 	stbi_image_free(pData);
 	RING_API_ACCEPTINTVALUE(2) ;
 	RING_API_ACCEPTINTVALUE(3) ;
@@ -164,7 +164,7 @@ RING_FUNC(ring_stbi_load_from_file)
 	p3 = RING_API_GETINTPOINTER(4);
 	nChannels = (int) RING_API_GETNUMBER(5);
 	pData = stbi_load_from_file((FILE *) RING_API_GETCPOINTER(1,"FILE"),p1,p2,p3,nChannels) ;
-	RING_API_RETSTRING2(pData, (*p1) * (*p2) * nChannels);
+	RING_API_RETSTRING2(pData, (*p1) * (*p2) * (nChannels ? nChannels : *p3));
 	stbi_image_free(pData);
 	RING_API_ACCEPTINTVALUE(2) ;
 	RING_API_ACCEPTINTVALUE(3) ;


### PR DESCRIPTION
## Bug

`stbi_load()` and `stbi_load_from_memory()` return an empty string (0 bytes) when `desired_channels=0` (native format). Image dimensions are populated correctly, but pixel data is lost.

## Root Cause

Commit `7f9cff9e0` changed the data size calculation from `(*p1) * (*p2) * (*p3)` to `(*p1) * (*p2) * nChannels` to fix channel conversion (e.g. loading RGBA image as RGB). However, `nChannels` is the *desired* channels parameter — when `desired_channels=0` (use native format), the size becomes 0 and no data is copied.

| `desired_channels` | Original `*p3` | Broken `nChannels` | Fix `nChannels ? nChannels : *p3` |
|---|---|---|---|
| 0 (native) | ✓ | ✗ size=0 | ✓ uses `*p3` |
| 3 (force RGB) | ✗ overread | ✓ | ✓ uses `nChannels` |
| 4 (force RGBA) | ✗ overread | ✓ | ✓ uses `nChannels` |

Per stb_image.h documentation (line 145): *"n will always be the number that it would have been if you said 0"* — meaning `*p3` reports the file's native channels, not the output channels. So `*p3` is only correct when `desired_channels=0`, and `nChannels` is only correct when it's non-zero.

## Fix

Use `nChannels ? nChannels : *p3` — selects actual output channel count in all cases.

**Files changed:**
- `extensions/ringstbimage/stbimage.cf`
- `extensions/ringstbimage/ring_stbimage.c` — regenerated via `gencode.sh`
