### PR TITLE
Add Parameterized Query Support to RingSQLite

### DIFF
--- a/documents/source/sqlite.txt
+++ b/documents/source/sqlite.txt
@@ -48,7 +48,12 @@ Syntax:
 
 .. code-block:: ring
 
-	sqlite_execute(SQLite Object,cSQLStatement)
+	sqlite_execute(SQLite Object,cSQLStatement [, aParams])
+
+The second form uses parameterized queries where ``aParams`` is a list of values
+bound to ``?`` placeholders in the SQL statement. This prevents SQL injection
+by separating query structure from data. Bind types are auto-detected:
+strings use text binding, numbers use double/int binding, and NULL values use null binding.
 
 .. index:: 
 	pair: SQLite; sqlite_close()
@@ -106,6 +111,44 @@ The next code create a SQLite database, add new records then display the data.
 		? x[:name] 
 	next
 	sqlite_close(oSQLite) 
+
+Parameterized Queries Example
+=============================
+
+The next code demonstrates parameterized queries to prevent SQL injection.
+
+.. code-block:: ring
+
+	load "sqlitelib.ring"
+
+	oSQLite = sqlite_init()
+
+	sqlite_open(oSQLite,":memory:")
+
+	sqlite_execute(oSQLite, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)")
+
+	# Safe inserts using parameterized queries
+	sqlite_execute(oSQLite, "INSERT INTO users (name, age) VALUES (?, ?)", ["Alice", 30])
+	sqlite_execute(oSQLite, "INSERT INTO users (name, age) VALUES (?, ?)", ["Bob", 25])
+
+	# Parameterized SELECT
+	aResult = sqlite_execute(oSQLite, "SELECT * FROM users WHERE age > ?", [28])
+	for x in aResult
+		? x[:name]
+	next
+
+	# SQL injection is safely handled - input treated as literal string
+	aResult = sqlite_execute(oSQLite, "SELECT * FROM users WHERE name = ?", ["' OR '1'='1"])
+	? "Injection attempt rows: " + len(aResult)   # 0 rows
+
+	sqlite_close(oSQLite)
+
+Output:
+
+.. code-block:: ring
+
+	Alice
+	Injection attempt rows: 0
 
 Output:
 

--- a/extensions/ringsqlite/ring_vmsqlite.c
+++ b/extensions/ringsqlite/ring_vmsqlite.c
@@ -109,6 +109,67 @@ int ring_vm_sqlite_callback ( void *data, int argc, char **argv, char **ColName 
 	return 0 ;
 }
 
+void ring_vm_sqlite_execute_prepared ( void *pPointer, void *pSqlite )
+{
+	ring_sqlite *psqlite  ;
+	sqlite3_stmt *pStmt  ;
+	int rc, nCol, x, nParamCount  ;
+	List *pList, *pList2, *pParams  ;
+	const unsigned char *cColVal  ;
+	psqlite = (ring_sqlite *) pSqlite ;
+	if ( ! RING_API_ISLIST(3) ) {
+		RING_API_ERROR(RING_API_BADPARATYPE);
+		return ;
+	}
+	pParams = RING_API_GETLIST(3) ;
+	rc = sqlite3_prepare_v2(psqlite->db, RING_API_GETSTRING(2), -1, &pStmt, NULL);
+	if ( rc != SQLITE_OK ) {
+		RING_API_ERROR(sqlite3_errmsg(psqlite->db));
+		return ;
+	}
+	nParamCount = ring_list_getsize(pParams);
+	for ( x = 1 ; x <= nParamCount ; x++ ) {
+		if ( ring_list_isstring(pParams, x) ) {
+			rc = sqlite3_bind_text(pStmt, x, ring_list_getstring(pParams, x), -1, SQLITE_TRANSIENT);
+		} else if ( ring_list_isdouble(pParams, x) ) {
+			rc = sqlite3_bind_double(pStmt, x, ring_list_getdouble(pParams, x));
+		} else if ( ring_list_isint(pParams, x) ) {
+			rc = sqlite3_bind_int(pStmt, x, ring_list_getint(pParams, x));
+		} else if ( ring_list_gettype(pParams, x) == ITEMTYPE_NOTHING ) {
+			rc = sqlite3_bind_null(pStmt, x);
+		} else {
+			rc = sqlite3_bind_text(pStmt, x, "", 0, SQLITE_TRANSIENT);
+		}
+		if ( rc != SQLITE_OK ) {
+			RING_API_ERROR(sqlite3_errmsg(psqlite->db));
+			sqlite3_finalize(pStmt);
+			return ;
+		}
+	}
+	pList = RING_API_NEWLIST ;
+	while ( 1 ) {
+		rc = sqlite3_step(pStmt);
+		if ( rc == SQLITE_ROW ) {
+			pList2 = ring_list_newlist(pList);
+			nCol = sqlite3_column_count(pStmt);
+			for ( x = 0 ; x < nCol ; x++ ) {
+				List *pColList  ;
+				pColList = ring_list_newlist(pList2);
+				ring_list_addstring(pColList, sqlite3_column_name(pStmt, x));
+				cColVal = sqlite3_column_text(pStmt, x);
+				ring_list_addstring(pColList, cColVal ? (const char *) cColVal : "NULL");
+			}
+		} else if ( rc == SQLITE_DONE ) {
+			break ;
+		} else {
+			RING_API_ERROR(sqlite3_errmsg(psqlite->db));
+			break ;
+		}
+	}
+	sqlite3_finalize(pStmt);
+	RING_API_RETLIST(pList);
+}
+
 void ring_vm_sqlite_execute ( void *pPointer )
 {
 	ring_sqlite *psqlite  ;
@@ -116,7 +177,7 @@ void ring_vm_sqlite_execute ( void *pPointer )
 	List *pList  ;
 	char *ErrMsg  ;
 	ErrMsg = NULL ;
-	if ( RING_API_PARACOUNT != 2 ) {
+	if ( RING_API_PARACOUNT != 2 && RING_API_PARACOUNT != 3 ) {
 		RING_API_ERROR(RING_API_MISS2PARA);
 		return ;
 	}
@@ -126,9 +187,13 @@ void ring_vm_sqlite_execute ( void *pPointer )
 			return ;
 		}
 		if ( psqlite->db ) {
-			pList = RING_API_NEWLIST ;
-			rc = sqlite3_exec(psqlite->db,RING_API_GETSTRING(2),ring_vm_sqlite_callback,(void *) pList,&ErrMsg);
-			RING_API_RETLIST(pList);
+			if ( RING_API_PARACOUNT == 2 ) {
+				pList = RING_API_NEWLIST ;
+				rc = sqlite3_exec(psqlite->db,RING_API_GETSTRING(2),ring_vm_sqlite_callback,(void *) pList,&ErrMsg);
+				RING_API_RETLIST(pList);
+			} else {
+				ring_vm_sqlite_execute_prepared(pPointer, psqlite);
+			}
 		}
 	} else {
 		RING_API_ERROR(RING_API_BADPARATYPE);

--- a/extensions/ringsqlite/ring_vmsqlite.h
+++ b/extensions/ringsqlite/ring_vmsqlite.h
@@ -17,6 +17,8 @@ int ring_vm_sqlite_callback ( void *data, int argc, char **argv, char **ColName 
 
 void ring_vm_sqlite_execute ( void *pPointer ) ;
 
+void ring_vm_sqlite_execute_prepared ( void *pPointer, void *psqlite ) ;
+
 void ring_vm_sqlite_freefunc ( void *pState,void *pPointer ) ;
 /* Constants */
 #define RING_VM_POINTER_SQLITE "sqlite"

--- a/samples/UsingSQLite/01_basic_operations.ring
+++ b/samples/UsingSQLite/01_basic_operations.ring
@@ -1,0 +1,36 @@
+# Example 1: Basic SQLite Database Operations
+# Create a database, insert records, and query them
+
+load "sqlitelib.ring"
+
+oSQLite = sqlite_init()
+sqlite_open(oSQLite, "mytest.db")
+
+# Create table
+sqlite_execute(oSQLite, "
+	CREATE TABLE COMPANY (
+		ID INT PRIMARY KEY     NOT NULL,
+		NAME           TEXT    NOT NULL,
+		AGE            INT     NOT NULL,
+		ADDRESS        CHAR(50),
+		SALARY         REAL )
+")
+
+# Insert records
+sqlite_execute(oSQLite, "
+	INSERT INTO COMPANY (ID,NAME,AGE,ADDRESS,SALARY)
+	VALUES  (1, 'Mahmoud' , 29, 'Jeddah', 20000.00 ),
+		(2, 'Ahmed'   , 27, 'Jeddah', 15000.00 ),
+		(3, 'Mohammed', 31, 'Egypt' , 20000.00 ),
+		(4, 'Ibrahim' , 24, 'Egypt ', 65000.00 )
+")
+
+# Query and display
+aResult = sqlite_execute(oSQLite, "select * from COMPANY")
+for x in aResult
+	for t in x
+		? t[2] + nl
+	next
+next
+
+sqlite_close(oSQLite)

--- a/samples/UsingSQLite/02_parameterized_queries.ring
+++ b/samples/UsingSQLite/02_parameterized_queries.ring
@@ -1,0 +1,36 @@
+# Example 2: Parameterized Queries (SQL Injection Safe)
+# Uses sqlite_execute with a 3rd list parameter for bound values
+
+load "sqlitelib.ring"
+
+oSQLite = sqlite_init()
+sqlite_open(oSQLite, ":memory:")
+
+# Create table
+sqlite_execute(oSQLite, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)")
+
+# Safe inserts using parameterized queries
+sqlite_execute(oSQLite, "INSERT INTO users (name, age) VALUES (?, ?)", ["Alice", 30])
+sqlite_execute(oSQLite, "INSERT INTO users (name, age) VALUES (?, ?)", ["Bob", 25])
+sqlite_execute(oSQLite, "INSERT INTO users (name, age) VALUES (?, ?)", ["Charlie", 35])
+
+# Parameterized SELECT with number
+aResult = sqlite_execute(oSQLite, "SELECT * FROM users WHERE age > ?", [28])
+? "Users with age > 28:"
+for x in aResult
+	? x[:name]
+next
+
+# Parameterized SELECT with string
+aResult = sqlite_execute(oSQLite, "SELECT * FROM users WHERE name = ?", ["Bob"])
+? nl + "User named Bob:"
+for x in aResult
+	? x[:name] + " - age: " + x[:age]
+next
+
+# SQL injection is safely handled - the input is treated as a literal string
+aResult = sqlite_execute(oSQLite, "SELECT * FROM users WHERE name = ?", ["' OR '1'='1"])
+? nl + "Injection attempt result (0 rows):"
+? "Row count: " + len(aResult)
+
+sqlite_close(oSQLite)

--- a/samples/UsingSQLite/03_null_rowid_errors.ring
+++ b/samples/UsingSQLite/03_null_rowid_errors.ring
@@ -1,0 +1,42 @@
+# Example 3: NULL Values, last_insert_rowid, and Error Handling
+
+load "sqlitelib.ring"
+
+oSQLite = sqlite_init()
+sqlite_open(oSQLite, ":memory:")
+
+sqlite_execute(oSQLite, "CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT, price REAL)")
+
+# Insert with NULL value
+sqlite_execute(oSQLite, "INSERT INTO products (name, price) VALUES (?, ?)", ["Widget", NULL])
+sqlite_execute(oSQLite, "INSERT INTO products (name, price) VALUES (?, ?)", ["Gadget", 9.99])
+
+# Get last insert rowid via SQL
+aResult = sqlite_execute(oSQLite, "SELECT last_insert_rowid() as rid")
+? "Last inserted rowid: " + aResult[1][1][2]
+
+# Update with parameterized query
+sqlite_execute(oSQLite, "UPDATE products SET price = ? WHERE name = ?", [4.99, "Widget"])
+
+# Display all products
+aResult = sqlite_execute(oSQLite, "SELECT * FROM products")
+? nl + "All products:"
+for x in aResult
+	? x[:name] + " - price: " + x[:price]
+next
+
+# Delete with parameterized query
+sqlite_execute(oSQLite, "DELETE FROM products WHERE name = ?", ["Gadget"])
+
+aResult = sqlite_execute(oSQLite, "SELECT * FROM products")
+? nl + "After deleting Gadget:"
+for x in aResult
+	? x[:name] + " - price: " + x[:price]
+next
+
+# Error handling using sqlite_errmsg()
+# Attempt an invalid SQL statement
+sqlite_execute(oSQLite, "SELECT * FROM nonexistent_table")
+? nl + "Error message: " + sqlite_errmsg(oSQLite)
+
+sqlite_close(oSQLite)


### PR DESCRIPTION
Hello Mahmoud,

I have submitted a Pull Request to improve the **RingSQLite** extension by adding support for prepared statements to prevent SQL injection.

### **Summary of Changes**
*   **Security Fix:** Added an optional 3rd parameter to `sqlite_execute()` to support parameterized queries.
*   **Implementation:** Uses `sqlite3_prepare_v2`, `sqlite3_bind_*`, and `sqlite3_step`. It automatically detects types (String, Number, and NULL).
*   **Backward Compatibility:** The existing 2-argument syntax remains unchanged and fully functional.

### **Modified Files**
*   **`ring_vmsqlite.c/h`**: Implemented `ring_vm_sqlite_execute_prepared()`.
*   **`samples/UsingSQLite/`**: Added 3 new samples covering basic CRUD, parameterized queries, and error handling.
*   **`documents/source/sqlite.txt`**: Updated documentation with the new syntax and examples.

### **Usage Example**
```ring
# New Safe Method (Separates SQL from Data)
sqlite_execute(oDB, "SELECT * FROM users WHERE name = ?", [cInput])
```

### **Testing Results**
*   **Injection Protection:** Verified that payloads like `OR 1=1` and `DROP TABLE` are neutralized.
*   **Compatibility:** Existing codebases using the 2-argument form work perfectly.
*   **Functionality:** Confirmed correct behavior for `last_insert_rowid()`, `sqlite_errmsg()`, and all CRUD operations.

Best regards,  
Youssef