### PR TITLE
Fix VM crash using Private inside eval() + strtod errno portability (musl)

### DIFF
--- a/language/src/stmt.c
+++ b/language/src/stmt.c
@@ -228,8 +228,15 @@ int ring_parser_class(Parser *pParser) {
 		if (pParser->lClassStart == 1) {
 			/* Generate Code */
 			ring_parser_icg_retnull(pParser);
-			/* Change Label After Class to BlockFlag to Jump to Private */
-			pList = ring_parser_icg_getoperationlist(pParser, pParser->nClassMark);
+			/*
+			**  Change Label After Class to BlockFlag to Jump to Private
+			**  nClassMark (from newlabel2) is a global instruction number that
+			**  includes nInstructionsCount, while getoperationlist() indexes the
+			**  local pGenCode list - subtract the offset, otherwise using Private
+			**  inside eval() reads outside the list and crashes the VM
+			*/
+			pList = ring_parser_icg_getoperationlist(
+			    pParser, pParser->nClassMark - pParser->pRingState->nInstructionsCount);
 			ring_parser_icg_setopcode(pParser, pList, ICO_BLOCKFLAG);
 			ring_parser_icg_addoperandint(pParser, pList, ring_parser_icg_newlabel(pParser));
 			ring_parser_icg_newoperation(pParser, ICO_PRIVATE);

--- a/language/src/vmexpr.c
+++ b/language/src/vmexpr.c
@@ -900,7 +900,13 @@ RING_API double ring_vm_stringtonum(VM *pVM, const char *cStr) {
 		return RING_ZEROF;
 	}
 	nResult = strtod(cStr, &cEndStr);
-	if (nResult == 0 && (errno != 0)) {
+	/*
+	**  Some libc implementations (musl) set errno to EINVAL when no conversion
+	**  is performed, while MSVC/glibc keep errno unchanged - without the
+	**  cEndStr != cStr check, ("test" = 5) raises Error (R41) on those
+	**  platforms instead of being evaluated as False
+	*/
+	if (nResult == 0 && (errno != 0) && (cEndStr != cStr)) {
 		if (errno == ERANGE) {
 			ring_vm_error(pVM, RING_VM_ERROR_NUMERICUNDERFLOW);
 		} else {


### PR DESCRIPTION
Hello Mahmoud,

While embedding the Ring VM (compiling `language/src` to WebAssembly with a resident `RingState` and running Ring's own samples plus the documentation examples through it, compared byte-for-byte against native `ring.exe`), I found two small VM bugs. Both are reproducible with the official 1.26/1.27 Windows releases, and both fixes are one-line guards.

## 1. Crash: using `Private` inside `eval()`

**Reproduce** (kills ring.exe with no error message):

```ring
see "before" + nl
eval("class q private b = 2")
see "after" + nl        # never reached
```

Any class containing a `Private` section defined through `eval()` crashes the process. The same class at the top level of a program works fine.

**Root cause** — `stmt.c`, `K_PRIVATE` handler: `pParser->nClassMark` comes from `ring_parser_icg_newlabel2()`, which returns a *global* instruction number:

```c
return ring_list_getsize(pParser->pGenCode) + pParser->pRingState->nInstructionsCount;
```

but the handler passes it directly to `ring_parser_icg_getoperationlist()`, which indexes the *local* `pGenCode` list. At the top level `nInstructionsCount` is 0, so the two coincide and everything works — but inside `eval()` (or any embedded state that already executed code) the offset is large, the lookup walks far past the end of `pGenCode`, and `ring_parser_icg_setopcode()` writes through an invalid item. In a WebAssembly build this traps immediately (`memory access out of bounds` in `ring_list_getitem_gc`, called from `ring_parser_class`), which is how it was caught; on Windows it corrupts memory and kills the process.

**Fix**: subtract `nInstructionsCount` at the lookup. Top-level programs are unaffected (offset zero).

## 2. Portability: `"test" = 5` raises R41 on musl-based builds

**Reproduce** (on any musl libc build — WebAssembly/wasi-libc, Alpine Linux, etc.):

```ring
? "test" = 5     # Error (R41) : Invalid numeric string
                 # expected (and MSVC/glibc behavior): 0
```

**Root cause** — `vmexpr.c`, `ring_vm_stringtonum()`: the first error branch fires when `strtod()` returned 0 with `errno` set. POSIX allows `strtod` to set `errno` to `EINVAL` when *no conversion is performed*, and musl does exactly that — while MSVC and glibc leave `errno` untouched. So on musl the plain no-conversion case (`"test"`) takes the error branch and raises `R41` before ever reaching the intended no-conversion branch (`cStr == cEndStr`) a few lines below.

**Fix**: add a `cEndStr != cStr` guard to the errno branch, so no-conversion input falls through to the existing no-conversion handling. Behavior on MSVC/glibc is unchanged.

## Validation

With these two fixes applied, my WebAssembly build of the VM (wasi-libc/musl) runs ~284 programs from `samples/` (AQuickStart, Language, Algorithms, DataStructure, ProblemSolving, General) and ~550 code blocks extracted from the documentation with output byte-identical to native `ring.exe` 1.27 on Windows — including every `Private`-using sample through `eval()`, and the full operators chapter.

(Since GitHub issues are disabled on this repository, I'm reporting both bugs as this PR per the "How to contribute?" chapter. Happy to adjust anything — comment style, splitting into two PRs, or moving the details to the Ring group.)

Thank you for Ring!

🤖 Generated with [Claude Code](https://claude.com/claude-code)
