### PR TITLE
Make the RING_VM_* build flags settable from the build

### DIFF
--- a/language/include/ext.h
+++ b/language/include/ext.h
@@ -2,12 +2,24 @@
 
 #ifndef ringext_h
 #define ringext_h
-#define RING_VM_LISTFUNCS 1
-#define RING_VM_MATH 1
-#define RING_VM_FILE 1
-#define RING_VM_OS 1
-#define RING_VM_REFMETA 1
-#define RING_VM_INFO 1
+#ifndef RING_VM_LISTFUNCS
+	#define RING_VM_LISTFUNCS 1
+#endif
+#ifndef RING_VM_MATH
+	#define RING_VM_MATH 1
+#endif
+#ifndef RING_VM_FILE
+	#define RING_VM_FILE 1
+#endif
+#ifndef RING_VM_OS
+	#define RING_VM_OS 1
+#endif
+#ifndef RING_VM_REFMETA
+	#define RING_VM_REFMETA 1
+#endif
+#ifndef RING_VM_INFO
+	#define RING_VM_INFO 1
+#endif
 #if RING_NODLL
 	#define RING_VM_DLL 0
 #else

--- a/language/src/dll_e.c
+++ b/language/src/dll_e.c
@@ -2,6 +2,8 @@
 
 #include "ring.h"
 
+#if RING_VM_DLL
+
 void ring_vm_dll_loadfunctions(RingState *pRingState) {
 	RING_API_REGISTER("loadlib", ring_vm_dll_loadlib);
 	RING_API_REGISTER("closelib", ring_vm_dll_closelib);
@@ -105,3 +107,5 @@ void ring_vm_dll_closealllibs(void *pPointer) {
 	}
 	ring_list_deleteallitems_gc(pVM->pRingState, pVM->pCLibraries);
 }
+
+#endif

--- a/language/src/file_e.c
+++ b/language/src/file_e.c
@@ -2,6 +2,8 @@
 
 #include "ring.h"
 
+#if RING_VM_FILE
+
 void ring_vm_file_loadfunctions(RingState *pRingState) {
 	RING_API_REGISTER("fopen", ring_vm_file_fopen);
 	RING_API_REGISTER("fclose", ring_vm_file_fclose);
@@ -918,4 +920,6 @@ void ring_vm_file_tempname(void *pPointer) {
 	RING_API_RETSTRING(_tmpfile);
 	#endif
 }
+#endif
+
 #endif

--- a/language/src/list_e.c
+++ b/language/src/list_e.c
@@ -2,6 +2,8 @@
 
 #include "ring.h"
 
+#if RING_VM_LISTFUNCS
+
 void ring_vm_list_loadfunctions(RingState *pRingState) {
 	/* Lists */
 	RING_API_REGISTER("add", ring_vm_listfuncs_add);
@@ -760,3 +762,5 @@ void ring_vm_listfuncs_refcount(void *pPointer) {
 	}
 	RING_API_ERROR(RING_API_BADPARACOUNT);
 }
+
+#endif

--- a/language/src/math_e.c
+++ b/language/src/math_e.c
@@ -2,6 +2,8 @@
 
 #include "ring.h"
 
+#if RING_VM_MATH
+
 void ring_vm_math_loadfunctions(RingState *pRingState) {
 	RING_API_REGISTER("sin", ring_vm_math_sin);
 	RING_API_REGISTER("cos", ring_vm_math_cos);
@@ -532,3 +534,5 @@ void ring_vm_math_checkoverflow(void *pPointer) {
 		RING_API_ERROR(RING_API_BADPARATYPE);
 	}
 }
+
+#endif

--- a/language/src/meta_e.c
+++ b/language/src/meta_e.c
@@ -2,6 +2,8 @@
 
 #include "ring.h"
 
+#if RING_VM_REFMETA
+
 void ring_vm_refmeta_loadfunctions(RingState *pRingState) {
 	/* Functions */
 	RING_API_REGISTER("locals", ring_vm_refmeta_locals);
@@ -876,3 +878,5 @@ void ring_vm_refmeta_parentclassname(void *pPointer) {
 		RING_API_ERROR(RING_API_BADPARATYPE);
 	}
 }
+
+#endif

--- a/language/src/os_e.c
+++ b/language/src/os_e.c
@@ -2,6 +2,8 @@
 
 #include "ring.h"
 
+#if RING_VM_OS
+
 void ring_vm_os_loadfunctions(RingState *pRingState) {
 	RING_API_REGISTER("ismsdos", ring_vm_os_ismsdos);
 	RING_API_REGISTER("iswindows", ring_vm_os_iswindows);
@@ -495,4 +497,6 @@ void ring_vm_os_syssleep(void *pPointer) {
 	RING_API_RETNUMBER(RING_ZEROF);
 	#endif
 }
+#endif
+
 #endif

--- a/language/src/vminfo_e.c
+++ b/language/src/vminfo_e.c
@@ -2,6 +2,8 @@
 
 #include "ring.h"
 
+#if RING_VM_INFO
+
 void ring_vm_info_loadfunctions(RingState *pRingState) {
 	RING_API_REGISTER("ringvm_fileslist", ring_vm_info_ringvmfileslist);
 	RING_API_REGISTER("ringvm_calllist", ring_vm_info_ringvmcalllist);
@@ -522,3 +524,5 @@ void ring_vm_info_ringvmwriteringo(void *pPointer) {
 	ring_objfile_writecontent(pVM->pRingState, RING_API_GETSTRING(1), pListFiles, pListFunctions, pListClasses,
 				  pListPackages, pListCode);
 }
+
+#endif


### PR DESCRIPTION
Hello Mahmoud,

A small build-system report. As with the last one, please treat the diff as
illustration rather than something to merge — I know the C is generated from
PWCT.

## What happens

`language/include/ext.h` offers six switches for the extension modules:

```c
#define RING_VM_LISTFUNCS 1
#define RING_VM_MATH 1
#define RING_VM_FILE 1
#define RING_VM_OS 1
#define RING_VM_REFMETA 1
#define RING_VM_INFO 1
```

They read as build-time options, and `ring.h` already honours them — it
conditions each `#include "math_e.h"` and so on. But because the defines are
unconditional, a value passed from the build is overridden as soon as `ext.h`
is included:

```
gcc -DRING_VM_MATH=0 ...     # no effect: the flag is 1 regardless
```

So the option cannot be exercised. `RING_VM_DLL` immediately below is the
exception, and shows the intended shape — it is already conditional, on
`RING_NODLL`.

## A second, related point

Fixing only the above makes setting a flag to `0` fail to build: `ring.h` stops
declaring the module's prototypes, but the module's `.c` file is still compiled
and references them.

```
vminfo_e.c:6:40: error: use of undeclared identifier 'ring_vm_info_ringvmfileslist'
```

Each module therefore also needs to compile to nothing when its flag is off —
the same condition `ring.h` already applies to the header include.

## What this PR does

Two mechanical edits, no behaviour change:

1. `ext.h` — the six defines wrapped in `#ifndef`, exactly as `RING_VM_DLL` is
   already conditional.
2. `math_e.c`, `file_e.c`, `os_e.c`, `list_e.c`, `meta_e.c`, `vminfo_e.c` and
   `dll_e.c` — each body wrapped in `#if RING_VM_<MODULE>` … `#endif`, after
   the `#include "ring.h"` line.

Point 2 also settles an existing case: with `RING_NODLL` set, `ext.h` defines
`RING_VM_DLL 0` and `ring.h` drops `dll_e.h`, yet `dll_e.c` is still compiled.
Builds get away with it today only by removing that file from the source list
by hand.

## Verified

Against `master` (98914829), compiled to `wasm32-wasi` with `zig cc`:

- **With the flags at their defaults, the output binary is byte-identical** —
  same SHA-256 as the build before this change. Nothing moves for anyone who
  does not set a flag.
- **With `-DRING_VM_REFMETA=0 -DRING_VM_INFO=0 -DRING_VM_MATH=0` and no other
  change** — every source file still in the build list — it compiles cleanly and
  the binary goes from 363,218 to 327,210 bytes (−36 KB, −9.9%).

Being able to leave out reflection or the file layer matters most for embedded
and WebAssembly targets, where the whole VM ships to the user on every page
load. This came up while building [RingScript](https://github.com/mayouni/ringscript),
which runs the Ring VM in the browser.

Thank you for Ring,
Mansour
